### PR TITLE
Change schema attribute on CalculatorView to property to avoid migration errors

### DIFF
--- a/fee_calculator/apps/calculator/filters.py
+++ b/fee_calculator/apps/calculator/filters.py
@@ -2,7 +2,6 @@
 import logging
 
 from django.db.models import Q
-from django.db.utils import ProgrammingError
 import django_filters
 from django_filters.constants import EMPTY_VALUES
 from django_filters.fields import Lookup
@@ -19,34 +18,29 @@ logger = logging.getLogger('laa-calc')
 class CalculatorSchema(ManualSchema):
 
     def __init__(self, fields, *args, **kwargs):
-        try:
-            for unit in models.Unit.objects.all():
-                fields.append(
-                    coreapi.Field(unit.pk.lower(), **{
-                        'required': False,
-                        'location': 'query',
-                        'type': 'number',
-                        'description': (
-                            'The number of units of the named unit'
-                        ),
-                    }),
-                )
+        for unit in models.Unit.objects.all():
+            fields.append(
+                coreapi.Field(unit.pk.lower(), **{
+                    'required': False,
+                    'location': 'query',
+                    'type': 'number',
+                    'description': (
+                        'The number of units of the named unit'
+                    ),
+                }),
+            )
 
-            for modifier in models.ModifierType.objects.all():
-                fields.append(
-                    coreapi.Field(modifier.name.lower(), **{
-                        'required': False,
-                        'location': 'query',
-                        'type': 'number',
-                        'description': (
-                            'The number of units of the named modifier type'
-                        ),
-                    }),
-                )
-        except ProgrammingError as e:
-            # avoids issues caused by migration not having been applied yet
-            logger.exception(e)
-
+        for modifier in models.ModifierType.objects.all():
+            fields.append(
+                coreapi.Field(modifier.name.lower(), **{
+                    'required': False,
+                    'location': 'query',
+                    'type': 'number',
+                    'description': (
+                        'The number of units of the named modifier type'
+                    ),
+                }),
+            )
         super().__init__(fields, *args, **kwargs)
 
 

--- a/fee_calculator/apps/calculator/views.py
+++ b/fee_calculator/apps/calculator/views.py
@@ -250,12 +250,15 @@ class PriceViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     scheme_relation_name = 'scheme'
 
 
-class classproperty:
+class cached_class_property:
     def __init__(self, getter):
         self.getter = getter
+        self.cached = None
 
     def __get__(self, instance, clazz):
-        return self.getter(clazz)
+        if self.cached is None:
+            self.cached = self.getter(clazz)
+        return self.cached
 
 
 class CalculatorView(views.APIView):
@@ -266,7 +269,7 @@ class CalculatorView(views.APIView):
     allowed_methods = ['GET']
     filter_backends = (backends.DjangoFilterBackend,)
 
-    @classproperty
+    @cached_class_property
     def schema(cls):
         return CalculatorSchema(fields=[
             coreapi.Field('scheme_pk', **{

--- a/fee_calculator/apps/calculator/views.py
+++ b/fee_calculator/apps/calculator/views.py
@@ -250,49 +250,60 @@ class PriceViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     scheme_relation_name = 'scheme'
 
 
+class classproperty:
+    def __init__(self, getter):
+        self.getter = getter
+
+    def __get__(self, instance, clazz):
+        return self.getter(clazz)
+
+
 class CalculatorView(views.APIView):
     """
     Calculate total fee amount
     """
 
     allowed_methods = ['GET']
-    schema = CalculatorSchema(fields=[
-        coreapi.Field('scheme_pk', **{
-            'required': True,
-            'location': 'path',
-            'type': 'integer',
-            'description': '',
-        }),
-        coreapi.Field('fee_type_code', **{
-            'required': True,
-            'location': 'query',
-            'type': 'string',
-            'description': '',
-        }),
-        coreapi.Field('scenario', **{
-            'required': True,
-            'location': 'query',
-            'type': 'integer',
-            'description': '',
-        }),
-        coreapi.Field('advocate_type', **{
-            'required': False,
-            'location': 'query',
-            'type': 'string',
-            'description': (
-                'Note the query will return prices with `advocate_type_id` '
-                'either matching the value or null.'),
-        }),
-        coreapi.Field('offence_class', **{
-            'required': False,
-            'location': 'query',
-            'type': 'string',
-            'description': (
-                'Note the query will return prices with `offence_class_id` '
-                'either matching the value or null.'),
-        })
-    ])
     filter_backends = (backends.DjangoFilterBackend,)
+
+    @classproperty
+    def schema(cls):
+        return CalculatorSchema(fields=[
+            coreapi.Field('scheme_pk', **{
+                'required': True,
+                'location': 'path',
+                'type': 'integer',
+                'description': '',
+            }),
+            coreapi.Field('fee_type_code', **{
+                'required': True,
+                'location': 'query',
+                'type': 'string',
+                'description': '',
+            }),
+            coreapi.Field('scenario', **{
+                'required': True,
+                'location': 'query',
+                'type': 'integer',
+                'description': '',
+            }),
+            coreapi.Field('advocate_type', **{
+                'required': False,
+                'location': 'query',
+                'type': 'string',
+                'description': (
+                    'Note the query will return prices with `advocate_type_id` '
+                    'either matching the value or null.'),
+            }),
+            coreapi.Field('offence_class', **{
+                'required': False,
+                'location': 'query',
+                'type': 'string',
+                'description': (
+                    'Note the query will return prices with `offence_class_id` '
+                    'either matching the value or null.'),
+            })
+        ])
 
     def get_param(self, param_name, required=False, default=None):
         value = self.request.query_params.get(param_name, default)


### PR DESCRIPTION
As the CalculatorSchema references DB models, having it as an attribute
would cause errors if django commands were run before the associated
migrations were applied.

Slightly less hacky than the previous fix.