### PR TITLE
Add bash installation for the final docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install -r requirements/base.txt
 RUN python manage.py collectstatic
 
 FROM python:3.5-alpine as deployimg
-RUN apk add --no-cache ca-certificates postgresql-dev uwsgi-python
+RUN apk add --no-cache ca-certificates postgresql-dev uwsgi-python bash
 COPY --from=baseimg /app /app
 COPY --from=baseimg /usr/local/lib/python3.5/site-packages /usr/local/lib/python3.5/site-packages
 WORKDIR /app


### PR DESCRIPTION
Bash shell is required by scripts which need to be run after new image creation