### PR TITLE
Import data on the docker image run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ ARG SECRET_KEY
 ENV DJANGO_SECRET_KEY=$SECRET_KEY
 ENV DJANGO_SETTINGS_MODULE=fee_calculator.settings.docker
 
-ADD . /app
 WORKDIR /app
+ADD requirements/base.txt /app/requirements/base.txt
 RUN pip install -r requirements/base.txt
+
+ADD . /app
 RUN python manage.py collectstatic
 
 FROM python:3.5-alpine as deployimg
@@ -15,4 +17,4 @@ RUN apk add --no-cache ca-certificates postgresql-dev uwsgi-python bash
 COPY --from=baseimg /app /app
 COPY --from=baseimg /usr/local/lib/python3.5 /usr/local/lib/python3.5
 WORKDIR /app
-CMD python manage.py migrate --no-input && uwsgi --ini uwsgi.ini
+ENTRYPOINT python manage.py loaddata advocatetype feetype offenceclass price scenario scheme unit modifier modifiertype && python manage.py migrate --no-input && uwsgi --ini uwsgi.ini


### PR DESCRIPTION
To avoid issues with kubernetes cluster executing commands on live image
we can deploy an image and import the data during the startup.
As it takes a while website won't be available during this process.