### PR TITLE
Add fees for interim payments when a warrant is issued and executed

### DIFF
--- a/fee_calculator/apps/calculator/fixtures/modifier.json
+++ b/fee_calculator/apps/calculator/fixtures/modifier.json
@@ -222,5 +222,19 @@
     "priority": 0,
     "strict_range": true
   }
+},
+{
+  "model": "calculator.modifier",
+  "pk": 18,
+  "fields": {
+    "limit_from": 3,
+    "limit_to": null,
+    "fixed_percent": "0.00",
+    "percent_per_unit": "0.00",
+    "modifier_type": 7,
+    "required": true,
+    "priority": 0,
+    "strict_range": false
+  }
 }
 ]

--- a/fee_calculator/apps/calculator/fixtures/modifiertype.json
+++ b/fee_calculator/apps/calculator/fixtures/modifiertype.json
@@ -52,5 +52,14 @@
     "description": "Third in which a trial cracked",
     "unit": "THIRD"
   }
+},
+{
+  "model": "calculator.modifiertype",
+  "pk": 7,
+  "fields": {
+    "name": "WARRANT_INTERVAL",
+    "description": "Whole months between warrant issue and execution",
+    "unit": "MONTH"
+  }
 }
 ]

--- a/fee_calculator/apps/calculator/fixtures/scenario.json
+++ b/fee_calculator/apps/calculator/fixtures/scenario.json
@@ -292,5 +292,75 @@
   "fields": {
     "name": "Interim payment - retrial start"
   }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 47,
+  "fields": {
+    "name": "Warrant issued - trial"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 48,
+  "fields": {
+    "name": "Warrant issued - trial (before plea hearing)"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 49,
+  "fields": {
+    "name": "Warrant issued - trial (after plea hearing)"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 50,
+  "fields": {
+    "name": "Warrant issued - trial (after trial start)"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 51,
+  "fields": {
+    "name": "Warrant issued - appeal against conviction"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 52,
+  "fields": {
+    "name": "Warrant issued - appeal against sentence"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 53,
+  "fields": {
+    "name": "Warrant issued - committal for sentence"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 54,
+  "fields": {
+    "name": "Warrant issued - breach of crown court order"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 55,
+  "fields": {
+    "name": "Warrant issued - retrial (after plea hearing)"
+  }
+},
+{
+  "model": "calculator.scenario",
+  "pk": 56,
+  "fields": {
+    "name": "Warrant issued - retrial (after trial start)"
+  }
 }
 ]

--- a/fee_calculator/apps/calculator/tests/test_calculation_agfs_10.py
+++ b/fee_calculator/apps/calculator/tests/test_calculation_agfs_10.py
@@ -7,10 +7,10 @@ from django.conf import settings
 from rest_framework import status
 
 from calculator.tests.lib.utils import scenario_ccr_to_id
-from calculator.tests.base import AgfsCalculatorTestCase
+from calculator.tests.base import AgfsCalculatorTestCase, Agfs10WarrantFeeTestMixin
 
 
-class Agfs10CalculatorTestCase(AgfsCalculatorTestCase):
+class Agfs10CalculatorTestCase(AgfsCalculatorTestCase, Agfs10WarrantFeeTestMixin):
     scheme_id = 3
     csv_path = os.path.join(
         os.path.dirname(__file__),

--- a/fee_calculator/apps/calculator/tests/test_calculation_lgfs_2016.py
+++ b/fee_calculator/apps/calculator/tests/test_calculation_lgfs_2016.py
@@ -2,12 +2,12 @@
 import os
 
 from calculator.tests.base import (
-    LgfsCalculatorTestCase, EvidenceProvisionFeeTestMixin
+    LgfsCalculatorTestCase, EvidenceProvisionFeeTestMixin, LgfsWarrantFeeTestMixin
 )
 
 
 class Lgfs2016CalculatorTestCase(
-    LgfsCalculatorTestCase, EvidenceProvisionFeeTestMixin
+    LgfsCalculatorTestCase, EvidenceProvisionFeeTestMixin, LgfsWarrantFeeTestMixin
 ):
     scheme_id = 2
     csv_path = os.path.join(

--- a/fee_calculator/apps/calculator/tests/test_calculation_lgfs_2017.py
+++ b/fee_calculator/apps/calculator/tests/test_calculation_lgfs_2017.py
@@ -2,12 +2,12 @@
 import os
 
 from calculator.tests.base import (
-    LgfsCalculatorTestCase, EvidenceProvisionFeeTestMixin
+    LgfsCalculatorTestCase, EvidenceProvisionFeeTestMixin, LgfsWarrantFeeTestMixin
 )
 
 
 class Lgfs2017CalculatorTestCase(
-    LgfsCalculatorTestCase, EvidenceProvisionFeeTestMixin
+    LgfsCalculatorTestCase, EvidenceProvisionFeeTestMixin, LgfsWarrantFeeTestMixin
 ):
     scheme_id = 4
     csv_path = os.path.join(


### PR DESCRIPTION
If a warrant is issued and executed over 3 months later, the supplier
can claim interim fees. These are represented by the addition of several
new scenarios for LGFS2016, LGFS2017 and AGFS10.

These are not new fees, but are an alternate way of claiming for existing
fees.