### PR TITLE
Allow for the existence of scenarios without corresponding codes

### DIFF
--- a/fee_calculator/apps/api/serializers.py
+++ b/fee_calculator/apps/api/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 from calculator.models import (
     Scheme, Scenario, FeeType, AdvocateType, OffenceClass, Price, Unit,
-    ModifierType, Modifier
+    ModifierType, Modifier, ScenarioCode
 )
 
 
@@ -50,7 +50,10 @@ class ScenarioSerializer(serializers.ModelSerializer):
 
     def get_code(self, obj):
         if hasattr(self, 'scheme'):
-            return obj.codes.get(scheme_type=self.scheme.base_type).code
+            try:
+                return obj.codes.get(scheme_type=self.scheme.base_type).code
+            except ScenarioCode.DoesNotExist:
+                pass
         return None
 
 

--- a/fee_calculator/apps/api/tests/test_advocate_type_api.py
+++ b/fee_calculator/apps/api/tests/test_advocate_type_api.py
@@ -4,6 +4,9 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from calculator.constants import SCHEME_TYPE
+from calculator.models import Scheme
+
 
 class AdvocateTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/advocate-types/'.format(
@@ -11,14 +14,20 @@ class AdvocateTypeApiTestCase(APITestCase):
     )
 
     def test_get_list_available(self):
-        response = self.client.get(self.endpoint.format(scheme=1))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data['results']), 0)
+        for scheme_id in Scheme.objects.filter(
+            base_type=SCHEME_TYPE.AGFS
+        ).values_list('id', flat=True):
+            response = self.client.get(self.endpoint.format(scheme=scheme_id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertGreater(len(response.data['results']), 0)
 
     def test_get_list_empty_for_lgfs(self):
-        response = self.client.get(self.endpoint.format(scheme=2))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['results']), 0)
+        for scheme_id in Scheme.objects.filter(
+            base_type=SCHEME_TYPE.LGFS
+        ).values_list('id', flat=True):
+            response = self.client.get(self.endpoint.format(scheme=scheme_id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(len(response.data['results']), 0)
 
     def test_get_detail_available(self):
         response = self.client.get(self.endpoint.format(scheme=1) + 'JRALONE/')

--- a/fee_calculator/apps/api/tests/test_fee_type_api.py
+++ b/fee_calculator/apps/api/tests/test_fee_type_api.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from calculator.models import Scheme
+
 
 class FeeTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/fee-types/'.format(
@@ -11,9 +13,10 @@ class FeeTypeApiTestCase(APITestCase):
     )
 
     def test_get_list_available(self):
-        response = self.client.get(self.endpoint.format(scheme=1))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data['results']), 0)
+        for scheme_id in Scheme.objects.all().values_list('id', flat=True):
+            response = self.client.get(self.endpoint.format(scheme=scheme_id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertGreater(len(response.data['results']), 0)
 
     def test_get_list_available_with_filters(self):
         response = self.client.get(

--- a/fee_calculator/apps/api/tests/test_modifier_type_api.py
+++ b/fee_calculator/apps/api/tests/test_modifier_type_api.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from calculator.models import Scheme
+
 
 class ModifierTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/modifier-types/'.format(
@@ -11,9 +13,10 @@ class ModifierTypeApiTestCase(APITestCase):
     )
 
     def test_get_list_available(self):
-        response = self.client.get(self.endpoint.format(scheme=1))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data['results']), 0)
+        for scheme_id in Scheme.objects.all().values_list('id', flat=True):
+            response = self.client.get(self.endpoint.format(scheme=scheme_id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertGreater(len(response.data['results']), 0)
 
     def test_get_list_available_with_filters(self):
         response = self.client.get(

--- a/fee_calculator/apps/api/tests/test_offence_class_api.py
+++ b/fee_calculator/apps/api/tests/test_offence_class_api.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from calculator.models import Scheme
+
 
 class OffenceClassApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/offence-classes/'.format(
@@ -11,14 +13,10 @@ class OffenceClassApiTestCase(APITestCase):
     )
 
     def test_get_list_available_1(self):
-        response = self.client.get(self.endpoint.format(scheme=1))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data['results']), 0)
-
-    def test_get_list_available_2(self):
-        response = self.client.get(self.endpoint.format(scheme=2))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data['results']), 0)
+        for scheme_id in Scheme.objects.all().values_list('id', flat=True):
+            response = self.client.get(self.endpoint.format(scheme=scheme_id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertGreater(len(response.data['results']), 0)
 
     def test_get_detail_available_1(self):
         response = self.client.get(self.endpoint.format(scheme=1) + 'A/')

--- a/fee_calculator/apps/api/tests/test_scenario_api.py
+++ b/fee_calculator/apps/api/tests/test_scenario_api.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from calculator.models import Scheme
+
 
 class ScenarioApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/scenarios/'.format(
@@ -11,9 +13,10 @@ class ScenarioApiTestCase(APITestCase):
     )
 
     def test_get_list_available(self):
-        response = self.client.get(self.endpoint.format(scheme=1))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data['results']), 0)
+        for scheme_id in Scheme.objects.all().values_list('id', flat=True):
+            response = self.client.get(self.endpoint.format(scheme=scheme_id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertGreater(len(response.data['results']), 0)
 
     def test_get_detail_available(self):
         response = self.client.get(self.endpoint.format(scheme=1) + '3/')

--- a/fee_calculator/apps/api/tests/test_unit_api.py
+++ b/fee_calculator/apps/api/tests/test_unit_api.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from calculator.models import Scheme
+
 
 class UnitApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/units/'.format(
@@ -11,9 +13,10 @@ class UnitApiTestCase(APITestCase):
     )
 
     def test_get_list_available(self):
-        response = self.client.get(self.endpoint.format(scheme=1))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data['results']), 0)
+        for scheme_id in Scheme.objects.all().values_list('id', flat=True):
+            response = self.client.get(self.endpoint.format(scheme=scheme_id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertGreater(len(response.data['results']), 0)
 
     def test_get_list_available_with_filters(self):
         response = self.client.get(


### PR DESCRIPTION
New scenarios that do not have a corresponding scenario in CCR/CCLF
do not have allocated scenario codes.