### PR TITLE
Prevent request warnings for tests of 4xx and 5xx responses

### DIFF
--- a/fee_calculator/apps/api/tests/test_advocate_type_api.py
+++ b/fee_calculator/apps/api/tests/test_advocate_type_api.py
@@ -8,6 +8,7 @@ from calculator.constants import SCHEME_TYPE
 from calculator.models import Scheme
 from calculator.tests.lib.utils import prevent_request_warnings
 
+
 class AdvocateTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/advocate-types/'.format(
         api=settings.API_VERSION

--- a/fee_calculator/apps/api/tests/test_advocate_type_api.py
+++ b/fee_calculator/apps/api/tests/test_advocate_type_api.py
@@ -6,7 +6,7 @@ from rest_framework.test import APITestCase
 
 from calculator.constants import SCHEME_TYPE
 from calculator.models import Scheme
-
+from calculator.tests.lib.utils import prevent_request_warnings
 
 class AdvocateTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/advocate-types/'.format(
@@ -33,6 +33,7 @@ class AdvocateTypeApiTestCase(APITestCase):
         response = self.client.get(self.endpoint.format(scheme=1) + 'JRALONE/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_404_for_nonexistent_id(self):
         response = self.client.get(self.endpoint.format(scheme=1) + 'LAWMAN/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/fee_calculator/apps/api/tests/test_fee_type_api.py
+++ b/fee_calculator/apps/api/tests/test_fee_type_api.py
@@ -5,7 +5,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from calculator.models import Scheme
-
+from calculator.tests.lib.utils import prevent_request_warnings
 
 class FeeTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/fee-types/'.format(
@@ -26,6 +26,7 @@ class FeeTypeApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(len(response.data['results']), 0)
 
+    @prevent_request_warnings
     def test_get_list_400_with_invalid_scenario(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -34,6 +35,7 @@ class FeeTypeApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data[0], '\'burps\' is not a valid `scenario`')
 
+    @prevent_request_warnings
     def test_get_list_400_with_nonexistent_offence_class(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -46,10 +48,12 @@ class FeeTypeApiTestCase(APITestCase):
         response = self.client.get(self.endpoint.format(scheme=1) + '7/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_404_for_fee_type_not_in_scheme(self):
         response = self.client.get(self.endpoint.format(scheme=2) + '7/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @prevent_request_warnings
     def test_404_for_nonexistent_id(self):
         response = self.client.get(self.endpoint.format(scheme=1) + '999999/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/fee_calculator/apps/api/tests/test_modifier_type_api.py
+++ b/fee_calculator/apps/api/tests/test_modifier_type_api.py
@@ -5,7 +5,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from calculator.models import Scheme
-
+from calculator.tests.lib.utils import prevent_request_warnings
 
 class ModifierTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/modifier-types/'.format(
@@ -26,6 +26,7 @@ class ModifierTypeApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(len(response.data['results']), 0)
 
+    @prevent_request_warnings
     def test_get_list_400_with_invalid_scenario(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -34,6 +35,7 @@ class ModifierTypeApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data[0], '\'burps\' is not a valid `scenario`')
 
+    @prevent_request_warnings
     def test_get_list_400_with_nonexistent_offence_class(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -42,6 +44,7 @@ class ModifierTypeApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data[0], '\'Z\' is not a valid `offence_class`')
 
+    @prevent_request_warnings
     def test_get_list_400_with_nonexistent_fee_type(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -54,10 +57,12 @@ class ModifierTypeApiTestCase(APITestCase):
         response = self.client.get(self.endpoint.format(scheme=1) + '1/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_404_for_fee_type_not_in_scheme(self):
         response = self.client.get(self.endpoint.format(scheme=2) + 'THIRD_CRACKED/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @prevent_request_warnings
     def test_404_for_nonexistent_id(self):
         response = self.client.get(self.endpoint.format(scheme=1) + '9999/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/fee_calculator/apps/api/tests/test_offence_class_api.py
+++ b/fee_calculator/apps/api/tests/test_offence_class_api.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from calculator.models import Scheme
+from calculator.tests.lib.utils import prevent_request_warnings
 
 
 class OffenceClassApiTestCase(APITestCase):
@@ -26,6 +27,7 @@ class OffenceClassApiTestCase(APITestCase):
         response = self.client.get(self.endpoint.format(scheme=3) + '1.2/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_404_for_nonexistent_id(self):
         response = self.client.get(self.endpoint.format(scheme=1) + 'Z/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/fee_calculator/apps/api/tests/test_price_api.py
+++ b/fee_calculator/apps/api/tests/test_price_api.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from calculator.tests.lib.utils import prevent_request_warnings
 
 class PriceApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/prices/'.format(
@@ -18,6 +19,7 @@ class PriceApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(len(response.data['results']), 0)
 
+    @prevent_request_warnings
     def test_get_list_400_with_invalid_scenario(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -25,6 +27,7 @@ class PriceApiTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @prevent_request_warnings
     def test_get_list_400_with_nonexistent_offence_class(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +

--- a/fee_calculator/apps/api/tests/test_scenario_api.py
+++ b/fee_calculator/apps/api/tests/test_scenario_api.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from calculator.models import Scheme
+from calculator.tests.lib.utils import prevent_request_warnings
 
 
 class ScenarioApiTestCase(APITestCase):
@@ -22,10 +23,12 @@ class ScenarioApiTestCase(APITestCase):
         response = self.client.get(self.endpoint.format(scheme=1) + '3/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_404_for_invalid_id(self):
         response = self.client.get(self.endpoint.format(scheme=1) + 'AS00001/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @prevent_request_warnings
     def test_404_for_nonexistent_id(self):
         response = self.client.get(self.endpoint.format(scheme=1) + '999999/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/fee_calculator/apps/api/tests/test_scheme_api.py
+++ b/fee_calculator/apps/api/tests/test_scheme_api.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from calculator.tests.lib.utils import prevent_request_warnings
 
 class SchemeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/'.format(api=settings.API_VERSION)
@@ -17,10 +18,12 @@ class SchemeApiTestCase(APITestCase):
         response = self.client.get('%s1/' % self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_returns_404_for_nonexistent_id(self):
         response = self.client.get('%s9999/' % self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @prevent_request_warnings
     def test_returns_404_for_invalid_id(self):
         response = self.client.get('%sburps/' % self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -30,6 +33,7 @@ class SchemeApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['results'][0]['id'], 1)
 
+    @prevent_request_warnings
     def test_400_on_invalid_date(self):
         response = self.client.get('%s?type=AGFS&case_date=4thJanuary2015' % self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/fee_calculator/apps/api/tests/test_unit_api.py
+++ b/fee_calculator/apps/api/tests/test_unit_api.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from calculator.models import Scheme
+from calculator.tests.lib.utils import prevent_request_warnings
 
 
 class UnitApiTestCase(APITestCase):
@@ -26,6 +27,7 @@ class UnitApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreater(len(response.data['results']), 0)
 
+    @prevent_request_warnings
     def test_get_list_400_with_invalid_scenario(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -34,6 +36,7 @@ class UnitApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data[0], '\'burps\' is not a valid `scenario`')
 
+    @prevent_request_warnings
     def test_get_list_400_with_nonexistent_offence_class(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -42,6 +45,7 @@ class UnitApiTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data[0], '\'Z\' is not a valid `offence_class`')
 
+    @prevent_request_warnings
     def test_get_list_400_with_nonexistent_fee_type(self):
         response = self.client.get(
             self.endpoint.format(scheme=1) +
@@ -54,10 +58,12 @@ class UnitApiTestCase(APITestCase):
         response = self.client.get(self.endpoint.format(scheme=1) + 'DAY/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @prevent_request_warnings
     def test_404_for_fee_type_not_in_scheme(self):
         response = self.client.get(self.endpoint.format(scheme=2) + 'PW/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @prevent_request_warnings
     def test_404_for_nonexistent_id(self):
         response = self.client.get(self.endpoint.format(scheme=1) + 'AEON/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/fee_calculator/apps/calculator/tests/lib/utils.py
+++ b/fee_calculator/apps/calculator/tests/lib/utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import logging
 
 BASIC_FEES_MAP = {
@@ -241,7 +240,6 @@ def prevent_request_warnings(original_function):
     """
     def new_function(*args, **kwargs):
         # raise logging level to ERROR
-
         logger = logging.getLogger('django.request')
         previous_logging_level = logger.getEffectiveLevel()
         logger.setLevel(logging.ERROR)

--- a/fee_calculator/apps/calculator/tests/lib/utils.py
+++ b/fee_calculator/apps/calculator/tests/lib/utils.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+import logging
+
 BASIC_FEES_MAP = {
     'FXACV': 'AGFS_APPEAL_CON',
     'FXASE': 'AGFS_APPEAL_SEN',
@@ -229,3 +232,24 @@ def scenario_id_to_clf(scenario_id):
     for key, value in CLF_SCENARIO_MAP.items():
         if value == scenario_id:
             return key
+
+
+def prevent_request_warnings(original_function):
+    """
+    If we need to test for 404s or 405s this decorator can prevent the
+    request class from throwing warnings.
+    """
+    def new_function(*args, **kwargs):
+        # raise logging level to ERROR
+
+        logger = logging.getLogger('django.request')
+        previous_logging_level = logger.getEffectiveLevel()
+        logger.setLevel(logging.ERROR)
+
+        # trigger original function that would throw warning
+        original_function(*args, **kwargs)
+
+        # lower logging level back to previous
+        logger.setLevel(previous_logging_level)
+
+    return new_function


### PR DESCRIPTION
Prevent log warnings for tests of 4xx and 5xx responses