### PR TITLE
Enable TLS on ingress specs

### DIFF
--- a/kubernetes_deploy/production/ingress.yaml
+++ b/kubernetes_deploy/production/ingress.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:
+  tls:
+  - hosts:
+    - laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
   rules:
   - host: laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
     http:

--- a/kubernetes_deploy/staging/ingress.yaml
+++ b/kubernetes_deploy/staging/ingress.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:
+  tls:
+  - hosts:
+    - laa-fee-calculator-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
   rules:
   - host: laa-fee-calculator-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
     http:


### PR DESCRIPTION
Cloud Platfrom is about to release Cert Manager for users
This will enable teams to be able to manage their own certificates on the
platform. This requires TLS to be enabled on the hostnames.