### PR TITLE
Filter production deploy to only be for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,9 +131,11 @@ workflows:
       - production_deploy_approval:
           type: approval
           requires:
-            - build
             - staging_deploy
+          filters:
+            branches:
+                only:
+                  - master
       - production_deploy:
           requires:
             - production_deploy_approval
-            - staging_deploy


### PR DESCRIPTION
#### What
Amend circleCI config to exclude prod deploy for branches

#### Why
Previous config allowed this which is not ideal and
prevents build and test passing without prod deploy.

Plus, when looking at merging multiple PRs you may only want to deploy
master once.
