### PR TITLE
Run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ ARG BUILD_TAG
 # pre-create directories
 WORKDIR /app
 
+# add non-root user and group with xenial first available uid, 1000, see /etc/login.defs, UID_MIN
+RUN addgroup --gid 1000 --system appgroup \
+&& adduser --uid 1000 --system appuser --ingroup appgroup
+
 # setup environment
 RUN \
   set -ex \
@@ -55,4 +59,5 @@ RUN python3 manage.py migrate --no-input \
     && python3 manage.py loadalldata \
     && python3 manage.py collectstatic --no-input
 
+USER 1000
 CMD uwsgi --ini uwsgi.ini


### PR DESCRIPTION
Add non-root user and run app as that user

#### What
Have API run as appuser

#### Why
More secure and standard required from cloud-platforms
for apps running in live-1.

see [pod security](https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#podsecuritypolicy) for more

#### How
 Use ubuntu:xenial long syntax for add user/group (not alpine)