### PR TITLE
Reduce frequency of ping.json calls

### DIFF
--- a/kubernetes_deploy/live-1/production/deployment.yaml
+++ b/kubernetes_deploy/live-1/production/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               - name: Host
                 value: localhost
           initialDelaySeconds: 15
-          periodSeconds: 10
+          periodSeconds: 15
         livenessProbe:
           httpGet:
             port: 8080
@@ -41,7 +41,7 @@ spec:
               - name: Host
                 value: localhost
           initialDelaySeconds: 15
-          periodSeconds: 30
+          periodSeconds: 60
         env:
         - name: DJANGO_SECRET_KEY
           valueFrom:

--- a/kubernetes_deploy/live-1/staging/deployment.yaml
+++ b/kubernetes_deploy/live-1/staging/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               - name: Host
                 value: localhost
           initialDelaySeconds: 15
-          periodSeconds: 10
+          periodSeconds: 15
         livenessProbe:
           httpGet:
             port: 8080
@@ -41,7 +41,7 @@ spec:
               - name: Host
                 value: localhost
           initialDelaySeconds: 15
-          periodSeconds: 30
+          periodSeconds: 60
         env:
         - name: DJANGO_SECRET_KEY
           valueFrom:


### PR DESCRIPTION
#### What
Reduce frequency of ping.json readiness and liveness probing

#### Why
Receiving [sentry errors](https://sentry.service.dsd.io/mojds/production-laa-fee-calculator/issues/34061/) related
to ping. The frequency is rather high and eats
up cpu and memory, potentially impacting service
unnecessarily.

I am reducing frequency to see if this reduces
the sentry error rate.