### PR TITLE
Update k8s APIs

### DIFF
--- a/kubernetes_deploy/live-1/production/deployment.yaml
+++ b/kubernetes_deploy/live-1/production/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: laa-fee-calculator

--- a/kubernetes_deploy/live-1/production/ingress.yaml
+++ b/kubernetes_deploy/live-1/production/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: laa-fee-calculator

--- a/kubernetes_deploy/live-1/staging/deployment.yaml
+++ b/kubernetes_deploy/live-1/staging/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: laa-fee-calculator

--- a/kubernetes_deploy/live-1/staging/ingress.yaml
+++ b/kubernetes_deploy/live-1/staging/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: laa-fee-calculator


### PR DESCRIPTION
#### What
Update staging k8s APIs

#### Ticket

[CBO-1347](https://dsdmoj.atlassian.net/browse/CBO-1347)

#### Why

Cloud platform is upgrading kubernetes from 1.15
to 1.16 on 12th July 2002 - and old APIs are deprecated.

#### How
- [X] update service account (so circleci has privs on new k8s api groups) - [PR merged](https://github.com/ministryofjustice/cloud-platform-environments/pull/2694)
- [x] update deployment config
- [x] update ingress config

see [user-guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html#removing-deprecated-apis-for-kubernetes-version-1-16) for more