### PR TITLE
Change rolling update to 100% `maxSurge`

### DIFF
--- a/kubernetes_deploy/live-1/production/deployment.yaml
+++ b/kubernetes_deploy/live-1/production/deployment.yaml
@@ -9,7 +9,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
-      maxSurge: 1
+      maxSurge: 100%
   selector:
     matchLabels:
       app: laa-fee-calculator-app

--- a/kubernetes_deploy/live-1/staging/deployment.yaml
+++ b/kubernetes_deploy/live-1/staging/deployment.yaml
@@ -9,7 +9,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
-      maxSurge: 1
+      maxSurge: 100%
   selector:
     matchLabels:
       app: laa-fee-calculator-app


### PR DESCRIPTION
#### what
Change rolling update to 100% `maxSurge`

#### Why

Change rolling update to 100% `maxSurge`
Helps to ensure all "new" pods are available before
any rolling over to any of them - preventing partial releases. 

Consistent with practices in other repos and, i believe, 
recommended by CP.