### PR TITLE
Bump circleci version 2.0 --> 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 references:
   container_config: &container_config


### PR DESCRIPTION
#### What
move to version 2.1 of circleci

#### Why
2 is getting old now and new features
are available in 2.1

see [overview](https://discuss.circleci.com/t/circleci-2-1-config-overview/26057) and [pipeline opt-in](https://circleci.com/docs/2.0/build-processing/#opting-in-to-pipelines-on-a-branch)