### PR TITLE
Parralellize test run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,15 @@ references:
 jobs:
   test:
     <<: *container_config
+    parallelism: 2
     steps:
       - checkout
       - *setup_python_env
-      - run: python3 manage.py test
+      - run:
+          name: Split and run tests
+          command: |
+            TESTDOTPATHS=$(circleci tests glob "fee_calculator/apps/calculator/tests/**/test_*.py" | sed -e 's|\.py||g' -e 's|/|.|g' | circleci tests split)
+            python3 manage.py test $TESTDOTPATHS --verbosity=1 --noinput
 
   build:
     <<: *container_config

--- a/.gitignore
+++ b/.gitignore
@@ -99,4 +99,4 @@ fee_calculator/static
 
 example_client/node_modules
 
-db.sqlite3
+*db.sqlite3


### PR DESCRIPTION
#### What
Split test run into 2 containers

#### Why
There are 9700 tests in total at the moment
taking over 12 minutes. This will increase
significantly when adding a new fee scheme.

#### How
add parrellism of 2 and glob the test dir
files for splitting by file name.

However, sed is needed to convert the file
names to python dotted paths as file paths
are not recognised by django `test` runs

Also had to add --noinput flag to ensure any existing
test db is destroyed. I believe this was only
needed because the test db had not been destroyed
and was not gitignored in a previous (since removed)
commit. It seems sensible to keep the flag for
automated tests on CI though.