### PR TITLE
Add ingress class annotations for non-live environments

### DIFF
--- a/kubernetes_deploy/live-1/dev/ingress.yaml
+++ b/kubernetes_deploy/live-1/dev/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: laa-fee-calculator
   namespace: laa-fee-calculator-dev
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: laa-fee-calculator-dev
 spec:
   rules:
     - host: laa-fee-calculator-dev.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/kubernetes_deploy/live-1/staging/ingress.yaml
+++ b/kubernetes_deploy/live-1/staging/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: laa-fee-calculator
   namespace: laa-fee-calculator-staging
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: laa-fee-calculator-staging
 spec:
   rules:
     - host: laa-fee-calculator-staging.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
WARNING resources/ingress.tf required for namespace first

#### What
Add ingress class annotations for non-live environments

#### Why
required by cloud platforms

> We're switching from one big nginx ingress to
having separate ingress controllers for each namespace.
You will need to add a one-line annotation to your ingress
definitions, but not until we ask you to do so. All traffic
to services on the cloud platform goes through ingress
controllers. Over-simplified, this is an AWS load-balancer
plus an nginx webserver, configured to route web traffic to
your service (generally based on the hostname of the web request).

> We originally decided to use a single* ingress controller for all
namespaces. i.e. one AWS load-balancer, and one nginx with a config
block for each ingress. This is partly for ease of management, and
partly to save money (because every AWS load-balancer costs around
$25/month, which adds up when you have several hundred of them).

> This architecture is not scaling well as we add more and more
ingresses, and we're starting to run into problems including nginx
pods running out of memory and crashing (possibly losing some web
requests when they do so), and ingress definitions taking a long
time to create/update. The underlying cause of both of these problems
is that the monolithic nginx configuration is unmanageably large.

> So, we have decided to change the architecture to have separate ingress
controllers for each namespace. i.e. every namespace will have its own
AWS load-balancer and nginx instance, which only handles web traffic for
the service(s) in that namespace.