### PR TITLE
Use new, dedicated ingress controller for production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,7 @@ references:
     run:
       name: Push laa-fee-calculator docker image
       command: |
-        login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
-        ${login}
+        aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
 
         component=app
         docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${component}-${CIRCLE_SHA1}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,10 @@ ENV APP_GIT_COMMIT=${COMMIT_ID}
 ENV APP_BUILD_DATE=${BUILD_DATE}
 ENV APP_BUILD_TAG=${BUILD_TAG}
 
+# temporary "escape hatch" for setuputools > 50.0
+# https://github.com/pypa/setuptools/issues/2352
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
+
 # clearing data to prevent UNIQUE constraint violations when rebuilding locally, at least
 RUN python3 manage.py migrate --no-input \
     && python3 manage.py cleardata \

--- a/kubernetes_deploy/live-1/production/ingress.yaml
+++ b/kubernetes_deploy/live-1/production/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: laa-fee-calculator
   namespace: laa-fee-calculator-production
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: laa-fee-calculator-production
 spec:
   rules:
     - host: laa-fee-calculator-production.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/kubernetes_deploy/live-1/scripts/build.sh
+++ b/kubernetes_deploy/live-1/scripts/build.sh
@@ -25,7 +25,7 @@ function _build() {
   printf "\e[33mRegistry tag: $docker_registry_tag\e[0m\n"
   printf "\e[33m------------------------------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  $(aws ecr --profile "$aws_profile" get-login --no-include-email --region "$region")
+  aws ecr --profile "$aws_profile" get-login-password --region ${region} | docker login --username AWS --password-stdin $docker_endpoint
 
   printf '\e[33mBuilding app container image locally...\e[0m\n'
   docker build \


### PR DESCRIPTION
#### What
Use new, dedicated ingress controller for production

#### Why
As with dev and staging, cloud platforms
are wanting to move all namespaces to be using
their own ingress controllers.

#### Also
The build broke on this branch but not beucause of the above changes. 
Firstly, it broke as a result of the docker version no longer being able to use
`get-login` (which was deprecated and now defunct), and secondly it broke
because of a new version of setuptools (v50.0.0) - see commits for more detail
