### PR TITLE
Revert ingress annotations

### DIFF
--- a/kubernetes_deploy/live-1/dev/ingress.yaml
+++ b/kubernetes_deploy/live-1/dev/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: laa-fee-calculator
   namespace: laa-fee-calculator-dev
-  annotations:
-    kubernetes.io/ingress.class: laa-fee-calculator-dev
 spec:
   rules:
     - host: laa-fee-calculator-dev.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/kubernetes_deploy/live-1/production/ingress.yaml
+++ b/kubernetes_deploy/live-1/production/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: laa-fee-calculator
   namespace: laa-fee-calculator-production
-  annotations:
-    kubernetes.io/ingress.class: laa-fee-calculator-production
 spec:
   rules:
     - host: laa-fee-calculator-production.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/kubernetes_deploy/live-1/staging/ingress.yaml
+++ b/kubernetes_deploy/live-1/staging/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: laa-fee-calculator
   namespace: laa-fee-calculator-staging
-  annotations:
-    kubernetes.io/ingress.class: laa-fee-calculator-staging
 spec:
   rules:
     - host: laa-fee-calculator-staging.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
#### What
Revert ingress annotations

#### Why
> In response to this morning's incident, we are moving
services' ingresses back to the default ingress controller
(we'll publish full details of why this is necessary in our
post-incident report).

> If you have a dedicated ingress controller (i.e. you have a
custom kubernetes.io/ingress.class annotation), please remove this
annotation from your ingress definitions before redeploying your service.

> If you redeploy your service and change back to your dedicated ingress
controller, after we have moved your ingress to the default ingress
controller, your service will be unavailable.