### PR TITLE
[CFP-183] Bump buildpack-deps:xenial to buildpack-deps:focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:xenial
+FROM buildpack-deps:focal
 
 ENV \
   LANG=en_GB.UTF-8 \


### PR DESCRIPTION
#### What
Bump ubuntu version to latest stable release
of Focal Fossa - `Ubuntu 20.04.3 LTS`

https://wiki.ubuntu.com/Releases
https://wiki.ubuntu.com/FocalFossa/ReleaseNotes

#### Ticket

[CFP-183](https://dsdmoj.atlassian.net/browse/CFP-183)

#### Why
`master` branch can no longer be built due
to OS and dependency conflicts.

Example error from xenial pip3 install:
```
Step 12/23 : RUN pip3 install -r requirements/base.txt
 ---> Running in 36092ef74ef
Traceback (most recent call last):
  File "/usr/local/bin/pip3", line 7, in <module>
    from pip._internal.cli.main import main
  File "/usr/local/lib/python3.5/dist-packages/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
The command '/bin/sh -c pip3 install -r requirements/base.txt' returned a non-zero code: 1
```

We were using xenial (ubuntu 16.04) which is
fixed to python 3.5.2, which was deprecated
and does not function with pip3, at least.

#### How
Bump to latest Long term support version of ubuntu
whose [python3-all-dev](https://packages.ubuntu.com/focal/python3-all-dev) package removes python2.7 and includes python3.8.10 (from testing on the box).