### PR TITLE
Fix docker-compose local build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     build:
       context: .
       args:
-        SECRET_KEY: CHANGE_ME
+        DJANGO_SECRET_KEY: 'NOT_A_REAL_SECRET_KEY'
     ports:
       - "8000:8080"
     links:
@@ -22,6 +22,7 @@ services:
     environment:
       ENV: local
       DEBUG: "True"
+      DJANGO_SECRET_KEY: 'NOT_A_REAL_SECRET_KEY'
       DB_NAME: fee_calculator
       DB_USERNAME: postgres
       DB_PASSWORD: postgres

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,12 +1,12 @@
 # Development
 
-### Requirements
+## Requirements
 
 * Python 3
 
 **NOTE:** Python 3.7 is not currently compatible with Django version in use [see here for more info](https://stackoverflow.com/a/48822656).
 
-### OS Dependencies
+## OS Dependencies
 
 
 * libxml2
@@ -79,3 +79,27 @@ run individual test
 ```
 ./manage.py test calculator.tests.test_calculation_agfs_12
 ```
+
+
+## Running locally using docker
+
+Tested using:
+```
+Docker Desktop version 3.5.2
+Docker version 20.10.7
+docker-compose version 1.29.2
+```
+
+### build
+```shell
+docker-compose build
+```
+
+### run locally
+```shell
+docker-compose up
+```
+
+### Open interactive API (swagger) documentation
+[localhost:8000/api/v1/docs](http://localhost:8000/api/v1/docs)
+


### PR DESCRIPTION
#### What
Fix docker-compose local build

#### Why
Previously broken due to
```
File "/usr/local/lib/python3.8/dist-packages/django/conf/__init__.py", line 176, in __init__
    raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.
```

#### How

The SECRET_KEY is taken from the DJANGO_SECRET_KEY, which
is what is actually needed as both an ENV var and a docker
 --build-arg.