### PR TITLE
Apply ModSecurity to fee calculator ingress with `Detection Only Mode`

### DIFF
--- a/kubernetes_deploy/live-1/dev/ingress.yaml
+++ b/kubernetes_deploy/live-1/dev/ingress.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-dev-blue
     external-dns.alpha.kubernetes.io/aws-weight: "100"
   name: laa-fee-calculator

--- a/kubernetes_deploy/live-1/staging/ingress.yaml
+++ b/kubernetes_deploy/live-1/staging/ingress.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-staging-blue
     external-dns.alpha.kubernetes.io/aws-weight: "100"
   name: laa-fee-calculator


### PR DESCRIPTION
#### What
ModSecurity is a web application firewall (WAF) that cloud platform supplies as an option. see [CP modsec guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall) for details.

#### Ticket
[CFP-298](https://dsdmoj.atlassian.net/browse/CFP-298)

`Detection Only Mode` is the default and means it just logs warnings
for a range of attacks.