### PR TITLE
Bump k8s ingress apiVersion networking.k8s.io/v1beta1 --> /v1 for "live"

### DIFF
--- a/kubernetes_deploy/live/dev/ingress.yaml
+++ b/kubernetes_deploy/live/dev/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -12,16 +12,22 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: laa-fee-calculator
-            servicePort: 8080
+            service:
+              name: laa-fee-calculator
+              port:
+                number: 8080
     - host: dev.laa-fee-calculator.service.justice.gov.uk
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: laa-fee-calculator
-            servicePort: 8080
+            service:
+              name: laa-fee-calculator
+              port:
+                number: 8080
   tls:
     - hosts:
       - laa-fee-calculator-dev.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
#### What
Bump ingress api version for live cluster namespaces

#### Ticket

Relates to [CFP-349] migration to live cluster

#### Why
"Live" clusters uses kubectl 1.19 which allows this
and removes deprecation warning:

```
Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```


[CFP-349]: https://dsdmoj.atlassian.net/browse/CFP-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ