### PR TITLE
require live deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,7 @@ workflows:
       - production_live_1_deploy_approval:
           type: approval
           requires:
+            - staging_live_deploy
             - staging_live_1_deploy
           filters:
             branches:


### PR DESCRIPTION
#### What
Require live and live-1 deploy prior to prodution deploy

![Screenshot 2021-12-17 at 16 08 09](https://user-images.githubusercontent.com/7016425/146573942-12cc5b63-056d-4728-87f1-abbef6c8ee53.png)



#### Ticket

[CFP-349]

#### Why

Since all traffic is against live cluster dev and staging namespaces
we should "require" deploying to live. I have left in the deploy to 
live-1 for now for completeness.





[CFP-349]: https://dsdmoj.atlassian.net/browse/CFP-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ