### PR TITLE
Send all traffic to "live" EKS cluster

### DIFF
--- a/kubernetes_deploy/live-1/production/ingress.yaml
+++ b/kubernetes_deploy/live-1/production/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-production-blue
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
   name: laa-fee-calculator
   namespace: laa-fee-calculator-production
 spec:

--- a/kubernetes_deploy/live/production/ingress.yaml
+++ b/kubernetes_deploy/live/production/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-production-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
   name: laa-fee-calculator
   namespace: laa-fee-calculator-production
 spec:


### PR DESCRIPTION
#### What
Send all traffic to the EKS cluster hosted
version of production. This has already been done
using kubectl directly editing the ingress config so
this is just to ensure it is kept that way.


#### Ticket

[CFP-350](https://dsdmoj.atlassian.net/browse/CFP-350)
