### PR TITLE
Remove live-1 production pods/server-instances

### DIFF
--- a/kubernetes_deploy/live-1/production/deployment.yaml
+++ b/kubernetes_deploy/live-1/production/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: laa-fee-calculator
   namespace: laa-fee-calculator-production
 spec:
-  replicas: 3
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION

#### What
Removes live-1 hosted versions of the app

#### Why
This removes live-1 hosted versions of the app as a
step to decommissioning and removing live-1 namespace
entirely.

Note this has already been done using `kubectl` to edit the 
deployment directly, and is therefore just to persist this.

#### Ticket
[CFP-350](https://dsdmoj.atlassian.net/browse/CFP-350)
