### PR TITLE
[CFP-366] Simplify env var dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
           name: Authenticate with cluster
           command: |
             echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
-            kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=${K8S_CLUSTER_URL}
+            kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_NAME}
             kubectl config set-credentials circleci --token=$(echo -n ${K8S_TOKEN} | base64 -d)
             kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
             kubectl config use-context ${K8S_CLUSTER_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,21 +128,21 @@ jobs:
       - build-image
       - push-image
 
-  dev_live_deploy:
+  dev_deploy:
     executor: cloud-platform-executor
     steps:
       - deploy-to:
           cluster: live
           environment: dev
 
-  staging_live_deploy:
+  staging_deploy:
     executor: cloud-platform-executor
     steps:
       - deploy-to:
           cluster: live
           environment: staging
 
-  production_live_deploy:
+  production_deploy:
     executor: cloud-platform-executor
     steps:
       - deploy-to:
@@ -162,37 +162,37 @@ workflows:
             - test
           context:
             - laa-fee-calculator-base
-      - dev_live_deploy_approval:
+      - dev_deploy_approval:
           type: approval
           requires:
             - build_and_push_image
-      - dev_live_deploy:
+      - dev_deploy:
           requires:
-            - dev_live_deploy_approval
+            - dev_deploy_approval
           context:
             - laa-fee-calculator-base
             - laa-fee-calculator-live-dev
-      - staging_live_deploy_approval:
+      - staging_deploy_approval:
           type: approval
           requires:
-            - dev_live_deploy
-      - staging_live_deploy:
+            - dev_deploy
+      - staging_deploy:
           requires:
-            - staging_live_deploy_approval
+            - staging_deploy_approval
           context:
             - laa-fee-calculator-base
             - laa-fee-calculator-live-staging
-      - production_live_deploy_approval:
+      - production_deploy_approval:
           type: approval
           requires:
-            - staging_live_deploy
+            - staging_deploy
           filters:
             branches:
                 only:
                   - master
-      - production_live_deploy:
+      - production_deploy:
           requires:
-            - production_live_deploy_approval
+            - production_deploy_approval
           context:
             - laa-fee-calculator-base
             - laa-fee-calculator-live-production


### PR DESCRIPTION
#### What
Use single K8S_CLUSTER_NAME env var with protocol prefix

#### Ticket

[CFP-366](https://dsdmoj.atlassian.net/browse/CFP-366)

#### Why
Simply config now that we are only using the new live/eks cluster

By deleting the cluster URL env var and relying on string concatentation
we can remove the need for an additional var. 
