### PR TITLE
Add scheduled docker image scan and monitor

### DIFF
--- a/.github/workflows/docker_image_scan.yml
+++ b/.github/workflows/docker_image_scan.yml
@@ -1,0 +1,71 @@
+name: Scan docker image
+on:
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  scan-docker-image:
+    runs-on: ubuntu-latest
+    name: Scan docker image
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build docker image
+      run: |
+        docker build \
+          --tag laa-fee-calculator:scan \
+          --build-arg DJANGO_SECRET_KEY=real-secret-not-needed-here \
+          --file Dockerfile .
+
+    - name: Scan docker image using snyk
+      id: image-scan
+      uses: snyk/actions/docker@master
+      continue-on-error: true
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        image: laa-fee-calculator:scan
+        args: --file=Dockerfile
+
+    - name: Monitor docker image using snyk
+      id: image-monitor
+      uses: snyk/actions/docker@master
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        command: monitor
+        image: laa-fee-calculator:scan
+        args: --file=Dockerfile
+
+    - name: Upload result to GitHub Code Scanning
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: snyk.sarif
+
+    - name: Slack notify failure
+      if: ${{ steps.image-scan.outcome == 'failure' }}
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_USERNAME: Snyk docker image scan
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: laa-cccd-alerts
+        SLACK_ICON_EMOJI: ':snyk:'
+        SLACK_COLOR: ${{ steps.image-scan.outcome }}
+        SLACK_TITLE: Scanned ${{ github.repository }}
+        SLACK_MESSAGE: docker scan detected vulnerabilites! @laa-claim-for-payment-devs
+        SLACK_LINK_NAMES: true
+        SLACK_FOOTER:
+
+    - name: Slack notify success
+      if: ${{ steps.image-scan.outcome == 'success' }}
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_USERNAME: Snyk docker image scan
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: laa-fee-calculator-development
+        SLACK_ICON_EMOJI: ':snyk:'
+        SLACK_COLOR: ${{ steps.image-scan.outcome }}
+        SLACK_TITLE: Scanned ${{ github.repository }}
+        SLACK_MESSAGE: docker scan found no vulnerabilites!
+        SLACK_FOOTER:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Fee calculator for LAA
 
 [![CircleCI](https://circleci.com/gh/ministryofjustice/laa-fee-calculator/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/laa-fee-calculator/tree/master)
+[![Known Vulnerabilities](https://snyk.io/test/github/ministryofjustice/laa-fee-calculator/badge.svg)](https://snyk.io/test/github/ministryofjustice/laa-fee-calculator)
 
 For development setup see instructions [here](./docs/DEVELOPMENT.md)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # laa-fee-calculator
 Fee calculator for LAA
 
+[![CircleCI](https://circleci.com/gh/ministryofjustice/laa-fee-calculator/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/laa-fee-calculator/tree/master)
+
 For development setup see instructions [here](./docs/DEVELOPMENT.md)
 
 ## Load data into calculator


### PR DESCRIPTION
#### What
Scan docker image for vulnerabilities and
setup a monitor of the master image

#### Ticket

[CFP-231](https://dsdmoj.atlassian.net/browse/CFP-231)

#### Why
So we can remove or mitigate against vulnerabilities

The reason for using a schedule is so that vulnerabilites
can be exposed irrespective of whether PRs are submitted
or not. This is especially important for repos like this
that do are left idle for long periods.

#### How
Run a `snyk test` and `snyk monitor` against an image
built from the default branch.
