### PR TITLE
Increase test run parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ commands:
 jobs:
   test:
     executor: cloud-platform-executor
-    parallelism: 2
+    parallelism: 6
     steps:
       - checkout
       - *setup_python_env


### PR DESCRIPTION
#### What
Increase test run parrallelism

#### Why
we are looking to do considerable work on fee
calculator in coming weeks and this will speed
up test runs.
