### PR TITLE
[CFP-399] Replace django-rest-swagger with drf_yasg

### DIFF
--- a/fee_calculator/apps/api/urls.py
+++ b/fee_calculator/apps/api/urls.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import url, include
+from django.conf.urls import url, re_path, include
 
 from rest_framework_nested import routers
-from rest_framework_swagger.views import get_swagger_view
+
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 from api.views import (
     SchemeViewSet, FeeTypeViewSet, ScenarioViewSet,
@@ -26,11 +29,24 @@ schemes_router.register(r'modifier-types', ModifierTypeViewSet,
                         basename='modifier-types')
 schemes_router.register(r'prices', PriceViewSet, basename='prices')
 
-schema_view = get_swagger_view(title='Calculator API')
+schema_view = get_schema_view(
+    openapi.Info(
+        title="LAA Fee Calculator",
+        default_version='v1',
+        #       description="Test description",
+        #       terms_of_service="TBC",
+        #       contact=openapi.Contact(email="contact@snippets.local"),
+        license=openapi.License(name="MIT License"),
+    ),
+    public=True,
+    permission_classes=[permissions.AllowAny],
+)
 
 urlpatterns = (
     url(r'^fee-schemes/(?P<scheme_pk>[^/.]+)/calculate/$', CalculatorView.as_view(), name='calculator'),
     url(r'^', include(router.urls)),
     url(r'^', include(schemes_router.urls)),
-    url(r'^docs/$', schema_view),
+    re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 )

--- a/fee_calculator/settings/base.py
+++ b/fee_calculator/settings/base.py
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'rest_framework',
-    'rest_framework_swagger',
+    'drf_yasg',
     'moj_irat',
     'corsheaders',
     'django_filters',
@@ -181,11 +181,6 @@ REST_FRAMEWORK = {
 
 
 API_VERSION = 'v1'
-
-
-SWAGGER_SETTINGS = {
-    'APIS_SORTER': 'alpha'
-}
 
 
 # Internationalization

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,5 @@
 Django>=2.1,<2.3
 django-moj-irat==0.7
-django-rest-swagger==2.2.0
 djangorestframework>=3.11.2,<3.14.0
 django-extended-choices==1.3.3
 django-cors-headers==3.11.0
@@ -11,3 +10,4 @@ pyyaml>=4.2b1
 six==1.16.0
 uWSGI==2.0.20
 raven>=6.6,<7
+drf_yasg>=1.20


### PR DESCRIPTION
#### What

Fixes #215 

#### Ticket

[Fee calculator dependency updates](https://dsdmoj.atlassian.net/browse/CFP-399)

#### Why

`django-rest-swagger` is deprecated and does not work with Django 3.*. `drf_yasg` is the suggested replacement.

#### How

Configured according to the [quick start guide.](https://github.com/axnsan12/drf-yasg#quickstart)

--------

#### TODO (wip)

 - [ ] Fix warnings; `[WARNING] view's ScenarioViewSet raised exception during schema generation; use `getattr(self, 'swagger_fake_view', False)` to detect and short-circuit this`
 - [ ] Set correct Open API information; description, terms of service and contact
 - [ ] Some parameters are missing. E.g., `/fee-schemes/` should have `type` and `case_date`