### PR TITLE
[CFP-399] Replace django-rest-swagger with drf-spectacular

### DIFF
--- a/fee_calculator/apps/api/filters.py
+++ b/fee_calculator/apps/api/filters.py
@@ -6,42 +6,11 @@ import django_filters
 from django_filters.constants import EMPTY_VALUES
 from django_filters.fields import Lookup
 from django_filters.rest_framework import filters
-from rest_framework.compat import coreapi
-from rest_framework.schemas import ManualSchema
 import six
 
 from calculator import models as calc_models
 
 logger = logging.getLogger('laa-calc')
-
-
-class CalculatorSchema(ManualSchema):
-
-    def __init__(self, fields, *args, **kwargs):
-        for unit in calc_models.Unit.objects.all():
-            fields.append(
-                coreapi.Field(unit.pk.lower(), **{
-                    'required': False,
-                    'location': 'query',
-                    'type': 'number',
-                    'description': (
-                        'Quantity of the price unit: {}'.format(unit.name)
-                    ),
-                }),
-            )
-
-        for modifier in calc_models.ModifierType.objects.all():
-            fields.append(
-                coreapi.Field(modifier.name.lower(), **{
-                    'required': False,
-                    'location': 'query',
-                    'type': 'number',
-                    'description': (
-                        'Price modifier: {}'.format(modifier.description)
-                    )
-                }),
-            )
-        super().__init__(fields, *args, **kwargs)
 
 
 class ModelOrNoneChoiceFilter(django_filters.ModelChoiceFilter):

--- a/fee_calculator/apps/api/serializers.py
+++ b/fee_calculator/apps/api/serializers.py
@@ -14,6 +14,17 @@ class SchemeListQuerySerializer(serializers.Serializer):
     case_date = serializers.CharField(help_text="Date for which you would like a list of applicable fee schemes",
                                       required=False)
 
+class BasePriceFilteredQuerySerializer(serializers.Serializer):
+    scenario = serializers.IntegerField(help_text='',
+                                        required=False,)
+    advocate_type = serializers.CharField(help_text='Note the query will return prices with `advocate_type_id` either matching the value or null.',
+                                          required=False,)
+    offence_class = serializers.CharField(help_text='Note the query will return prices with `offence_class_id` either matching the value or null.',
+                                          required=False,)
+    fee_type_code = serializers.CharField(help_text='',
+                                          required=False,)
+
+
 class SchemeSerializer(serializers.ModelSerializer):
     class Meta():
         model = Scheme

--- a/fee_calculator/apps/api/serializers.py
+++ b/fee_calculator/apps/api/serializers.py
@@ -7,6 +7,12 @@ from calculator.models import (
     ModifierType, Modifier, ScenarioCode
 )
 
+class SchemeListQuerySerializer(serializers.Serializer):
+    type = serializers.ChoiceField(help_text="Graduated fee scheme type",
+                                   choices=('AGFS', 'LGFS'),
+                                   required=False)
+    case_date = serializers.CharField(help_text="Date for which you would like a list of applicable fee schemes",
+                                      required=False)
 
 class SchemeSerializer(serializers.ModelSerializer):
     class Meta():

--- a/fee_calculator/apps/api/serializers.py
+++ b/fee_calculator/apps/api/serializers.py
@@ -94,7 +94,7 @@ class ScenarioSerializer(serializers.ModelSerializer):
             'code',
         )
 
-    def get_code(self, obj):
+    def get_code(self, obj) -> str:
         if hasattr(self, 'scheme'):
             try:
                 return obj.codes.get(scheme_type=self.scheme.base_type).code

--- a/fee_calculator/apps/api/serializers.py
+++ b/fee_calculator/apps/api/serializers.py
@@ -50,6 +50,10 @@ class CalculatorQuerySerializer(serializers.Serializer):
         print(e)
 
 
+class CalculatorResponseSerializer(serializers.Serializer):
+    serializers.DecimalField(max_digits=None, decimal_places=2)
+
+
 class SchemeSerializer(serializers.ModelSerializer):
     class Meta():
         model = Scheme

--- a/fee_calculator/apps/api/serializers.py
+++ b/fee_calculator/apps/api/serializers.py
@@ -29,18 +29,22 @@ class BasePriceFilteredQuerySerializer(serializers.Serializer):
 
 class CalculatorQuerySerializer(serializers.Serializer):
     class UnitField(serializers.DecimalField):
-        def __init__(self, name):
-            super().__init__(help_text=f'Quantity of the price unit: {name}',
-                            required=False,
-                            max_digits=100,
-                            decimal_places=5)
+        def __init__(self, name, **kwargs):
+            new_kwargs = {'help_text': f'Quantity of the price unit: {name}',
+                          'required': False,
+                          'max_digits': 100,
+                          'decimal_places': 5}
+            new_kwargs.update(kwargs)
+            super().__init__(**new_kwargs)
 
     class ModifierTypeField(serializers.DecimalField):
-        def __init__(self, description):
-            super().__init__(help_text=f'Price modifier: {description}',
-                            required=False,
-                            max_digits=100,
-                            decimal_places=5)
+        def __init__(self, description, **kwargs):
+            new_kwargs = {'help_text': f'Price modifier: {description}',
+                          'required': False,
+                          'max_digits': 100,
+                          'decimal_places': 5}
+            new_kwargs.update(kwargs)
+            super().__init__(**new_kwargs)
 
     scenario = serializers.IntegerField(help_text='', required=True,)
     fee_type_code = serializers.CharField(help_text='', required=True,)

--- a/fee_calculator/apps/api/urls.py
+++ b/fee_calculator/apps/api/urls.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import url, include
+from django.urls import path
 
 from rest_framework_nested import routers
-from rest_framework_swagger.views import get_swagger_view
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+
 
 from api.views import (
-    SchemeViewSet, FeeTypeViewSet, ScenarioViewSet,
-    OffenceClassViewSet, AdvocateTypeViewSet, PriceViewSet, CalculatorView,
-    UnitViewSet, ModifierTypeViewSet
+    SchemeViewSet,
+    # FeeTypeViewSet, ScenarioViewSet,
+    # OffenceClassViewSet, AdvocateTypeViewSet, PriceViewSet, CalculatorView,
+    # UnitViewSet, ModifierTypeViewSet
 )
 
 
@@ -15,22 +18,25 @@ router = routers.DefaultRouter()
 router.register(r'fee-schemes', SchemeViewSet, basename='fee-schemes')
 
 schemes_router = routers.NestedSimpleRouter(router, r'fee-schemes', lookup='scheme')
-schemes_router.register(r'fee-types', FeeTypeViewSet, basename='fee-types')
-schemes_router.register(r'scenarios', ScenarioViewSet, basename='scenarios')
-schemes_router.register(r'advocate-types', AdvocateTypeViewSet,
-                        basename='advocate-types')
-schemes_router.register(r'offence-classes', OffenceClassViewSet,
-                        basename='offence-classes')
-schemes_router.register(r'units', UnitViewSet, basename='units')
-schemes_router.register(r'modifier-types', ModifierTypeViewSet,
-                        basename='modifier-types')
-schemes_router.register(r'prices', PriceViewSet, basename='prices')
-
-schema_view = get_swagger_view(title='Calculator API')
+# schemes_router.register(r'fee-types', FeeTypeViewSet, basename='fee-types')
+# schemes_router.register(r'scenarios', ScenarioViewSet, basename='scenarios')
+# schemes_router.register(r'advocate-types', AdvocateTypeViewSet,
+#                         basename='advocate-types')
+# schemes_router.register(r'offence-classes', OffenceClassViewSet,
+#                         basename='offence-classes')
+# schemes_router.register(r'units', UnitViewSet, basename='units')
+# schemes_router.register(r'modifier-types', ModifierTypeViewSet,
+#                         basename='modifier-types')
+# schemes_router.register(r'prices', PriceViewSet, basename='prices')
 
 urlpatterns = (
-    url(r'^fee-schemes/(?P<scheme_pk>[^/.]+)/calculate/$', CalculatorView.as_view(), name='calculator'),
+    # url(r'^fee-schemes/(?P<scheme_pk>[^/.]+)/calculate/$', CalculatorView.as_view(), name='calculator'),
     url(r'^', include(router.urls)),
     url(r'^', include(schemes_router.urls)),
-    url(r'^docs/$', schema_view),
+
+    # drf-spectacular = OpenAPI3
+    path('oa3/schema/', SpectacularAPIView.as_view(), name='oa3_schema'),
+    path('oa3/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='oa3_schema'), name='oa3_swagger-ui'),
+    path('docs/', SpectacularSwaggerView.as_view(url_name='oa3_schema')),
 )
+

--- a/fee_calculator/apps/api/urls.py
+++ b/fee_calculator/apps/api/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url, include
 from django.urls import path
 
 from rest_framework_nested import routers
-from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from api.views import (
     SchemeViewSet,

--- a/fee_calculator/apps/api/urls.py
+++ b/fee_calculator/apps/api/urls.py
@@ -5,29 +5,32 @@ from django.urls import path
 from rest_framework_nested import routers
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
-
 from api.views import (
     SchemeViewSet,
-    # FeeTypeViewSet, ScenarioViewSet,
-    # OffenceClassViewSet, AdvocateTypeViewSet, PriceViewSet, CalculatorView,
-    # UnitViewSet, ModifierTypeViewSet
+    FeeTypeViewSet,
+    UnitViewSet,
+    ModifierTypeViewSet,
+    ScenarioViewSet,
+    OffenceClassViewSet,
+    AdvocateTypeViewSet,
+    PriceViewSet,
+    # CalculatorView,
 )
-
 
 router = routers.DefaultRouter()
 router.register(r'fee-schemes', SchemeViewSet, basename='fee-schemes')
 
 schemes_router = routers.NestedSimpleRouter(router, r'fee-schemes', lookup='scheme')
-# schemes_router.register(r'fee-types', FeeTypeViewSet, basename='fee-types')
-# schemes_router.register(r'scenarios', ScenarioViewSet, basename='scenarios')
-# schemes_router.register(r'advocate-types', AdvocateTypeViewSet,
-#                         basename='advocate-types')
-# schemes_router.register(r'offence-classes', OffenceClassViewSet,
-#                         basename='offence-classes')
-# schemes_router.register(r'units', UnitViewSet, basename='units')
-# schemes_router.register(r'modifier-types', ModifierTypeViewSet,
-#                         basename='modifier-types')
-# schemes_router.register(r'prices', PriceViewSet, basename='prices')
+schemes_router.register(r'fee-types', FeeTypeViewSet, basename='fee-types')
+schemes_router.register(r'scenarios', ScenarioViewSet, basename='scenarios')
+schemes_router.register(r'advocate-types', AdvocateTypeViewSet,
+                        basename='advocate-types')
+schemes_router.register(r'offence-classes', OffenceClassViewSet,
+                        basename='offence-classes')
+schemes_router.register(r'units', UnitViewSet, basename='units')
+schemes_router.register(r'modifier-types', ModifierTypeViewSet,
+                        basename='modifier-types')
+schemes_router.register(r'prices', PriceViewSet, basename='prices')
 
 urlpatterns = (
     # url(r'^fee-schemes/(?P<scheme_pk>[^/.]+)/calculate/$', CalculatorView.as_view(), name='calculator'),

--- a/fee_calculator/apps/api/urls.py
+++ b/fee_calculator/apps/api/urls.py
@@ -14,7 +14,7 @@ from api.views import (
     OffenceClassViewSet,
     AdvocateTypeViewSet,
     PriceViewSet,
-    # CalculatorView,
+    CalculatorView,
 )
 
 router = routers.DefaultRouter()
@@ -33,7 +33,7 @@ schemes_router.register(r'modifier-types', ModifierTypeViewSet,
 schemes_router.register(r'prices', PriceViewSet, basename='prices')
 
 urlpatterns = (
-    # url(r'^fee-schemes/(?P<scheme_pk>[^/.]+)/calculate/$', CalculatorView.as_view(), name='calculator'),
+    url(r'^fee-schemes/(?P<scheme_pk>[^/.]+)/calculate/$', CalculatorView.as_view(), name='calculator'),
     url(r'^', include(router.urls)),
     url(r'^', include(schemes_router.urls)),
 

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -138,7 +138,7 @@ class SchemeViewSet(OrderedReadOnlyModelViewSet):
                 )
             queryset = queryset.filter(base_type=base_type)
 
-        return queryset
+        return queryset.order_by(self.default_ordering or 'pk')
 
     def retrieve(self, request, pk=None):
         """

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -371,6 +371,7 @@ class AdvocateTypeViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     ),
     retrieve=extend_schema(
         description='Retrieve a single price',
+        parameters=[BasePriceFilteredQuerySerializer],
     )
 )
 class PriceViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
@@ -443,4 +444,3 @@ class CalculatorView(views.APIView):
         return Response({
             'amount': amount.quantize(Decimal('0.01'))
         })
-

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -12,7 +12,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from drf_spectacular.utils import (
-extend_schema_view, extend_schema, OpenApiParameter, OpenApiTypes
+    extend_schema_view, extend_schema, OpenApiParameter, OpenApiTypes
 )
 
 from calculator.constants import SCHEME_TYPE

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -31,7 +31,7 @@ logger = logging.getLogger('laa-calc')
 
 def get_param(request, param_name, required=False, default=None):
     value = request.query_params.get(param_name, default)
-    if value is None or value is '':
+    if value is None or value == '':
         if required:
             raise ValidationError('`%s` is a required field' % param_name)
     return value
@@ -43,7 +43,7 @@ def get_model_param(
 ):
     result = get_param(request, param_name, required, default)
     try:
-        if result is not None and result is not '':
+        if result is not None and result != '':
             if many:
                 candidates = model_class.objects.filter(**{lookup: result})
                 if len(candidates) == 0:
@@ -62,7 +62,7 @@ def get_model_param(
 def get_decimal_param(request, param_name, required=False, default=None):
     number = get_param(request, param_name, required, default)
     try:
-        if number is not None and number is not '':
+        if number is not None and number != '':
             number = Decimal(number)
     except InvalidOperation:
         raise ValidationError('`%s` must be a number' % param_name)

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -44,6 +44,7 @@ from .serializers import (
 
 logger = logging.getLogger('laa-calc')
 
+scheme_pk_parameter = OpenApiParameter('scheme_pk', OpenApiTypes.INT, OpenApiParameter.PATH)
 
 def get_param(request, param_name, required=False, default=None):
     value = request.query_params.get(param_name, default)
@@ -92,7 +93,6 @@ class OrderedReadOnlyModelViewSet(viewsets.ReadOnlyModelViewSet):
         queryset = super().filter_queryset(queryset)
         queryset = queryset.order_by(self.default_ordering or 'pk')
         return queryset
-
 
 @extend_schema_view(
     list=extend_schema(
@@ -197,6 +197,7 @@ class NestedSchemeMixin():
         context['scheme_pk'] = self.kwargs.get('scheme_pk')
         return context
 
+
 @extend_schema_view(
     list=extend_schema(
         parameters=[BasePriceFilteredQuerySerializer],
@@ -250,6 +251,8 @@ class BasePriceFilteredViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
             )
         return queryset
 
+
+@extend_schema(parameters=[scheme_pk_parameter,],)
 @extend_schema_view(
     list=extend_schema(
         description='Filterable list of fee types',
@@ -271,6 +274,8 @@ class FeeTypeViewSet(BasePriceFilteredViewSet):
     filter_class = FeeTypeFilter
     relation_name = 'fee_type'
 
+
+@extend_schema(parameters=[scheme_pk_parameter,],)
 @extend_schema_view(
     list=extend_schema(
         description='Filterable list of unit types',
@@ -287,6 +292,8 @@ class UnitViewSet(BasePriceFilteredViewSet):
     serializer_class = UnitSerializer
     relation_name = 'unit'
 
+
+@extend_schema(parameters=[scheme_pk_parameter,],)
 @extend_schema_view(
     list=extend_schema(
         description='Filterable list of modifier types',
@@ -305,6 +312,8 @@ class ModifierTypeViewSet(BasePriceFilteredViewSet):
     lookup_attr = 'values__pk'
     scheme_relation_name = 'values__prices__scheme'
 
+
+@extend_schema(parameters=[scheme_pk_parameter,],)
 @extend_schema_view(
     list=extend_schema(
         description='Filterable list of scenarios',
@@ -320,6 +329,8 @@ class ScenarioViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     queryset = Scenario.objects.all()
     serializer_class = ScenarioSerializer
 
+
+@extend_schema(parameters=[scheme_pk_parameter,],)
 @extend_schema_view(
     list=extend_schema(
         description='Filterable list of offence classes',
@@ -336,13 +347,15 @@ class OffenceClassViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     serializer_class = OffenceClassSerializer
     lookup_value_regex = '[^/]+'
 
+
+@extend_schema(parameters=[scheme_pk_parameter,],)
 @extend_schema_view(
     list=extend_schema(
         description='Filterable list of advocate types',
     ),
     retrieve=extend_schema(
         description='Retrieve a single advocate type',
-    )
+    ),
 )
 class AdvocateTypeViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     """
@@ -351,6 +364,7 @@ class AdvocateTypeViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     queryset = AdvocateType.objects.all()
     serializer_class = AdvocateTypeSerializer
 
+@extend_schema(parameters=[scheme_pk_parameter,],)
 @extend_schema_view(
     list=extend_schema(
         description='Filterable list of prices',
@@ -369,7 +383,7 @@ class PriceViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     filter_class = PriceFilter
     scheme_relation_name = 'scheme'
 
-# @extend_schema(responses=EmptyPayloadResponseSerializer)
+@extend_schema(parameters=[scheme_pk_parameter,],)
 @extend_schema_view(
     get=extend_schema(
         parameters=[CalculatorQuerySerializer],

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -31,6 +31,7 @@ from .serializers import (
     SchemeListQuerySerializer,
     BasePriceFilteredQuerySerializer,
     CalculatorQuerySerializer,
+    CalculatorResponseSerializer,
     SchemeSerializer,
     FeeTypeSerializer,
     UnitSerializer,
@@ -368,10 +369,11 @@ class PriceViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     filter_class = PriceFilter
     scheme_relation_name = 'scheme'
 
-
+# @extend_schema(responses=EmptyPayloadResponseSerializer)
 @extend_schema_view(
     get=extend_schema(
         parameters=[CalculatorQuerySerializer],
+        responses=CalculatorResponseSerializer
     )
 )
 class CalculatorView(views.APIView):

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -100,6 +100,7 @@ class OrderedReadOnlyModelViewSet(viewsets.ReadOnlyModelViewSet):
     ),
     retrieve=extend_schema(
         description='Retrieve a single graduated fee scheme',
+        parameters=[SchemeListQuerySerializer],
     )
 )
 class SchemeViewSet(OrderedReadOnlyModelViewSet):

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -10,7 +10,11 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.compat import coreapi
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
-from drf_spectacular.utils import extend_schema_view, extend_schema
+
+from drf_spectacular.utils import (
+extend_schema_view, extend_schema, OpenApiParameter, OpenApiTypes
+)
+
 from calculator.constants import SCHEME_TYPE
 
 from calculator.models import (
@@ -250,6 +254,9 @@ class BasePriceFilteredViewSet(NestedSchemeMixin, OrderedReadOnlyModelViewSet):
     ),
     retrieve=extend_schema(
         description='Retrieve a single fee type',
+        parameters=[
+            OpenApiParameter("is_basic", OpenApiTypes.BOOL, OpenApiParameter.QUERY),
+        ],
     )
 )
 class FeeTypeViewSet(BasePriceFilteredViewSet):

--- a/fee_calculator/apps/calculator/models.py
+++ b/fee_calculator/apps/calculator/models.py
@@ -14,7 +14,7 @@ class Scheme(models.Model):
     base_type = models.PositiveSmallIntegerField(choices=SCHEME_TYPE)
     description = models.CharField(max_length=255)
 
-    def type(self):
+    def type(self) -> str:
         return SCHEME_TYPE.for_value(self.base_type).constant
 
     def __str__(self):

--- a/fee_calculator/apps/calculator/tests/__init__.py
+++ b/fee_calculator/apps/calculator/tests/__init__.py
@@ -25,7 +25,7 @@ class PreloadDataDiscoverRunner(DiscoverRunner):
         self.setup_test_environment()
         old_config = self.setup_databases()
         suite = self.build_suite(test_labels, extra_tests)
-        self.run_checks()
+        self.run_checks(['default'])
         result = self.run_suite(suite)
         self.teardown_databases(old_config)
         self.teardown_test_environment()

--- a/fee_calculator/settings/base.py
+++ b/fee_calculator/settings/base.py
@@ -175,7 +175,6 @@ if os.environ.get('SENTRY_DSN'):
 
 
 REST_FRAMEWORK = {
-    # 'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 100

--- a/fee_calculator/settings/base.py
+++ b/fee_calculator/settings/base.py
@@ -101,6 +101,11 @@ DATABASES = {
     }
 }
 
+# Auto-created primary keys default
+# https://docs.djangoproject.com/en/4.0/releases/3.2/#customizing-type-of-auto-created-primary-keys
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 
 # Password validation
 # https://docs.djangoproject.com/en/1.10/ref/settings/#auth-password-validators

--- a/fee_calculator/settings/base.py
+++ b/fee_calculator/settings/base.py
@@ -47,7 +47,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'rest_framework',
-    'rest_framework_swagger',
+    'drf_spectacular',
     'moj_irat',
     'corsheaders',
     'django_filters',
@@ -170,7 +170,8 @@ if os.environ.get('SENTRY_DSN'):
 
 
 REST_FRAMEWORK = {
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    # 'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 100
 }
@@ -178,6 +179,13 @@ REST_FRAMEWORK = {
 
 API_VERSION = 'v1'
 
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Fee calculator API',
+    'DESCRIPTION': 'For retrieval and calculation of fees subject to the advocate and litigator graduated fee schemes',
+    'VERSION': '1.0.0',
+    # OTHER SETTINGS
+}
 
 SWAGGER_SETTINGS = {
     'APIS_SORTER': 'alpha'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 Django>=2.2,<2.3
 django-moj-irat==0.7
-django-rest-swagger==2.2.0
-djangorestframework>=3.11.2,<3.14.0
+drf-spectacular==0.21.2
+djangorestframework>=3.12,<3.14.0
 django-extended-choices==1.3.3
 django-cors-headers==3.11.0
 django-filter==2.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django>=2.2,<2.3
+Django>=3.2,<4.1
 django-moj-irat==0.7
 drf-spectacular==0.21.2
 djangorestframework>=3.12,<3.14.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Django>=3.2,<4.1
 django-moj-irat==0.7
-drf-spectacular==0.21.2
+drf-spectacular==0.22.0
 djangorestframework>=3.12,<3.14.0
 django-extended-choices==1.3.3
 django-cors-headers==3.11.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django>=2.1,<2.3
+Django>=2.2,<2.3
 django-moj-irat==0.7
 django-rest-swagger==2.2.0
 djangorestframework>=3.11.2,<3.14.0


### PR DESCRIPTION
## What
Move to modern openAPI/Swagger 3.0 standards and remove dependency on unmaintained `django-rest-swagger`, which is blocking update of django framework.

## How
* Removes `django-rest-swagger`
* Installs `drf-spectacular`
* Updates code to use `drf-spectacular`
* Updates Django to v3.x

## TODO:

- [x] Add missing parameters `type` and `case_date` ( `fee_schemes\:id`)
- [x] Add missing parameters from `prices` index to `prices/:id`
- [x] Aadd missing parameters `is_basic` (`fee_types\:id`)
- [x] Handle error warning with fallback
    ```
     Error #0: CalculatorView: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Ignoring view for now. 
    ```
- [x] handle warnings of `scheme_pk`  type on id paths `\nested\:id\resource\:id` 

    ```
    Warning #0: SchemeViewSet: SchemeSerializer: unable to resolve type hint for function "type". Consider using a type hint or @extend_schema_field. Defaulting to string.
    Warning #1: AdvocateTypeViewSet: could not derive type of path parameter "scheme_pk" because model "calculator.models.AdvocateType" contained no such field. Consider annotating parameter with @extend_schema. Defaulting to "string".
    Warning #2: CalculatorView: could not derive type of path parameter "scheme_pk" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:scheme_pk>) or annotating the parameter type with @extend_schema. Defaulting to "string".
    Warning #3: FeeTypeViewSet: could not derive type of path parameter "scheme_pk" because model "calculator.models.FeeType" contained no such field. Consider annotating parameter with @extend_schema. Defaulting to "string".
    Warning #4: ModifierTypeViewSet: could not derive type of path parameter "scheme_pk" because model "calculator.models.ModifierType" contained no such field. Consider annotating parameter with @extend_schema. Defaulting to "string".
    Warning #5: OffenceClassViewSet: could not derive type of path parameter "scheme_pk" because model "calculator.models.OffenceClass" contained no such field. Consider annotating parameter with @extend_schema. Defaulting to "string".
    Warning #6: ScenarioViewSet: could not derive type of path parameter "scheme_pk" because model "calculator.models.Scenario" contained no such field. Consider annotating parameter with @extend_schema. Defaulting to "string".
    Warning #7: ScenarioViewSet: ScenarioSerializer: unable to resolve type hint for function "get_code". Consider using a type hint or @extend_schema_field. Defaulting to string.
    Warning #8: UnitViewSet: could not derive type of path parameter "scheme_pk" because model "calculator.models.Unit" contained no such field. Consider annotating parameter with @extend_schema. Defaulting to "string".
    ```

- [x] Handle unresolved type warnings 

    ```
    Warning #0: SchemeViewSet: SchemeSerializer: unable to resolve type hint for function "type". Consider using a type hint or @extend_schema_field. Defaulting to string.
    Warning #7: ScenarioViewSet: ScenarioSerializer: unable to resolve type hint for function "get_code". Consider using a type hint or @extend_schema_field. Defaulting to string.
    ```
- [x] Handle unordered paginated list warning
```
UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'calculator.models.Scheme'> QuerySet.
  paginator = self.django_paginator_class(queryset, page_size)
```

