### PR TITLE
Add make commands DB console and DB reset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,16 @@ setup: #: Install virtual environment and requirements
 	`which python3` -m venv venv
 	${px} install -U setuptools pip wheel
 	${px} install -r requirements/base.txt
-reload: #: migrate, clear and load data
+server: # run app server
+	DEBUG="True" ${pyman} runserver 8000
+db: #: open db console
+	sqlite3 fee_calculator/db.sqlite3
+dbreload: #: migrate, clear and load data
 	${pyman} migrate
 	${pyman} cleardata
 	${pyman} loadalldata
-server:
-	DEBUG="True" ${pyman} runserver 8000
-test:
+dbreset: #: clear data and drop app tables
+	${pyman} flush --no-input
+	${pyman} migrate calculator zero
+test: #: run test suite
 	${pyman} test --verbosity=1 --noinput


### PR DESCRIPTION

#### What
Add simple shortcuts to run sqlite console
and to drop data undo all migrations (drop tables).

The `dbreset` followed by a `dbreload` helps test
setup from scratch, as during build process where
there is no DB to start with.

#### Why
Simplify common tasks
