### PR TITLE
CFP-531 Enable ModSecurity WAF on dev

### DIFF
--- a/kubernetes_deploy/live/dev/ingress.yaml
+++ b/kubernetes_deploy/live/dev/ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
   name: laa-fee-calculator
   namespace: laa-fee-calculator-dev
 spec:


### PR DESCRIPTION
#### What

Enable ModSecurity WAF on dev

Enables the ModSecurity WAF (web application firewall) on the dev environment following MOJ Cloud Platform [guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall). This configures the WAF to actively block malicious traffic using default MOJ configuration.

#### Why

To protect our applications from malicious requests.

This PR only affects the `dev` environment. I suggest merging this, testing it using the `dev` and `dev-lgfs` CCCD instances , and then opening similar PRs to update `staging` and `production` when we're satisfied that it's working correctly.
