### PR TITLE
CFP-531 Enable ModSecurity WAF on production

### DIFF
--- a/kubernetes_deploy/live/production/ingress.yaml
+++ b/kubernetes_deploy/live/production/ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
   name: laa-fee-calculator
   namespace: laa-fee-calculator-production
 spec:


### PR DESCRIPTION
#### What

Enable ModSecurity WAF on production

Enables the ModSecurity WAF (web application firewall) on the production environment following MOJ Cloud Platform [guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall). This configures the WAF to actively block malicious traffic using default MOJ configuration.

#### Why

To protect our applications from malicious requests.

This PR only affects the `production` environment and can be tested using the `production` CCCD instances or with the test app https://laa-fee-calculator-app.herokuapp.com/.