### PR TITLE
[CFP-551] How do we create a new fee scheme in Fee Calculator for CLAIR AGFS uplift?

### DIFF
--- a/fee_calculator/apps/calculator/fixtures/scheme.json
+++ b/fee_calculator/apps/calculator/fixtures/scheme.json
@@ -1,52 +1,62 @@
 [
-{
-  "model": "calculator.scheme",
-  "pk": 1,
-  "fields": {
-    "start_date": "2012-04-01",
-    "end_date": "2018-03-31",
-    "base_type": 1,
-    "description": "AGFS Fee Scheme 9"
+  {
+    "model": "calculator.scheme",
+    "pk": 1,
+    "fields": {
+      "start_date": "2012-04-01",
+      "end_date": "2018-03-31",
+      "base_type": 1,
+      "description": "AGFS Fee Scheme 9"
+    }
+  },
+  {
+    "model": "calculator.scheme",
+    "pk": 2,
+    "fields": {
+      "start_date": "2016-04-01",
+      "end_date": null,
+      "base_type": 2,
+      "description": "LGFS Fee Scheme 2016-04"
+    }
+  },
+  {
+    "model": "calculator.scheme",
+    "pk": 3,
+    "fields": {
+      "start_date": "2018-04-01",
+      "end_date": "2018-12-30",
+      "base_type": 1,
+      "description": "AGFS Fee Scheme 10"
+    }
+  },
+  {
+    "model": "calculator.scheme",
+    "pk": 4,
+    "fields": {
+      "start_date": "2018-12-31",
+      "end_date": "2020-09-16",
+      "base_type": 1,
+      "description": "AGFS Fee Scheme 11"
+    }
+  },
+  {
+    "model": "calculator.scheme",
+    "pk": 5,
+    "fields": {
+      "start_date": "2020-09-17",
+      "end_date": "2022-04-30",
+      "base_type": 1,
+      "description": "AGFS Fee Scheme 12 - CLAR accelerated measures"
+    }
+  },
+  {
+    "model": "calculator.scheme",
+    "pk": 6,
+    "fields": {
+      "start_date": "2022-05-01",
+      "end_date": null,
+      "base_type": 1,
+      "description": "AGFS Fee Scheme 13 - CLAIR"
+    }
   }
-},
-{
-  "model": "calculator.scheme",
-  "pk": 2,
-  "fields": {
-    "start_date": "2016-04-01",
-    "end_date": null,
-    "base_type": 2,
-    "description": "LGFS Fee Scheme 2016-04"
-  }
-},
-{
-  "model": "calculator.scheme",
-  "pk": 3,
-  "fields": {
-    "start_date": "2018-04-01",
-    "end_date": "2018-12-30",
-    "base_type": 1,
-    "description": "AGFS Fee Scheme 10"
-  }
-},
-{
-  "model": "calculator.scheme",
-  "pk": 4,
-  "fields": {
-    "start_date": "2018-12-31",
-    "end_date": "2020-09-16",
-    "base_type": 1,
-    "description": "AGFS Fee Scheme 11"
-  }
-},
-{
-  "model": "calculator.scheme",
-  "pk": 5,
-  "fields": {
-    "start_date": "2020-09-17",
-    "end_date": null,
-    "base_type": 1,
-    "description": "AGFS Fee Scheme 12 - CLAR accelerated measures"
-}
-}
 ]

--- a/fee_calculator/apps/calculator/management/commands/uplift.py
+++ b/fee_calculator/apps/calculator/management/commands/uplift.py
@@ -1,0 +1,41 @@
+from django.core.management import BaseCommand
+
+from calculator.models import (Scheme, Price)
+
+
+class Command(BaseCommand):
+    help = '''
+        Uplift all fees in a scheme
+    '''
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'scheme_id', type=int,
+            help='ID of fee scheme'
+        )
+        parser.add_argument(
+            'percentage', type=float,
+            help='Percentage to increase'
+        )
+
+    def handle(self, *args, **options):
+        scheme = Scheme.objects.get(pk=options['scheme_id'])
+        multiplier = 1 + options['percentage'] / 100
+        prices = Price.objects.filter(scheme=scheme)
+
+        for price in prices:
+            if price.fee_type is not None:
+                print('Fee type: {:s} ({:s})'.format(price.fee_type.name, price.fee_type.code))
+            else:
+                print('Fee type: UNKNOWN')
+
+            print('Scenario: {:s}'.format(price.scenario.name))
+            print('Advocate type: {:s}'.format(price.advocate_type.name if price.advocate_type is not None else '-'))
+
+            print('  Fixed fee: £{:.2f}'.format(price.fixed_fee))
+            price.fixed_fee = float(price.fixed_fee) * multiplier
+            print('  New fixed fee: £{:.2f}'.format(price.fixed_fee))
+            print('  Fee per unit: £{:.2f}'.format(price.fee_per_unit))
+            price.fee_per_unit = float(price.fee_per_unit) * multiplier
+            print('  New fee per unit: £{:.2f}'.format(price.fee_per_unit))
+            price.save()


### PR DESCRIPTION
#### What

Create a test AGFS fee scheme 13 based on AGFS fee scheme 12.

#### Ticket

[How do we create a new fee scheme in Fee Calculator for CLAIR AGFS uplift?](https://dsdmoj.atlassian.net/browse/CFP-551)

#### Why

#### How

No details have yet been decided so fake test values are used;

* All prices are increased by 500%. With such a ridiculously large increase it will be easier to see when the new fee scheme is being used.
* An arbitrary date, 1 April 2022, is chosen as the start of the new fee scheme.

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
