### PR TITLE
Update dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
   open-pull-requests-limit: 10
   rebase-strategy: "disabled"
   reviewers:
-  - "jsugarman"
+  - "mpw5"
   - "jrmhaig"
   - "naseberry"


### PR DESCRIPTION
#### What

Replaces `jsugarman` with `mpw5` in the list of reviewers in `.github/dependabot.yml`

#### Why

To reflect changes in the team and ensure the correct developers are notified of PRs.
