### PR TITLE
Resolve failure when running tests locally

### DIFF
--- a/fee_calculator/apps/calculator/tests/__init__.py
+++ b/fee_calculator/apps/calculator/tests/__init__.py
@@ -23,9 +23,10 @@ class PreloadDataDiscoverRunner(DiscoverRunner):
         Returns the number of tests that failed.
         """
         self.setup_test_environment()
-        old_config = self.setup_databases()
         suite = self.build_suite(test_labels, extra_tests)
-        self.run_checks(['default'])
+        databases = self.get_databases(suite)
+        old_config = self.setup_databases(aliases=databases)
+        self.run_checks()
         result = self.run_suite(suite)
         self.teardown_databases(old_config)
         self.teardown_test_environment()


### PR DESCRIPTION
Running the test suite locally fails with the following error:

```
File "/Users/markwhitaker/Workspaces/laa-fee-calculator/fee_calculator/apps/calculator/tests/__init__.py", line 28, in run_tests
    self.run_checks(['default'])
TypeError: DiscoverRunner.run_checks() takes 1 positional argument but 2 were given
```

The `['default']` argument was introduced in https://github.com/ministryofjustice/laa-fee-calculator/commit/c35e4dbde3cd4df21455b42cc4cea7ec41dd1481 but seems to be breaking local test runs. This reverts the change, which breaks the tests on Circle 😢 


