### PR TITLE
Update DEVELOPMENT.md to reflect Django upgrade

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,8 +2,8 @@
 
 ## Requirements
 
-* Python 3.10.0
-* Django 2.2.27
+* Python 3.10.x
+* Django 3.2.x
 
 ## OS Dependencies
 


### PR DESCRIPTION
#### What

Following the upgrade to Django 3.2, `docs/DEVELOPMENT.md` is out of date. This PR corrects the version of Django supported. 

It also reduces the specificity of the versions for Django and Python as we don't want to be updating this file every time a minor version is bumped.
