### PR TITLE
CFP-260 Use Alpine instead of Ubuntu for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,26 +20,17 @@ RUN addgroup --gid 1000 --system appgroup \
 # setup environment
 RUN \
   set -ex \
-  && apt-get update \
-  && apt-get install \
-    -y \
-    --no-install-recommends \
-    locales \
+  && apk update \
+  && apk add \
+    --virtual \
     tzdata \
-    software-properties-common \
-    build-essential \
+    build-base \
     rsync \
     gettext \
-    python3-all-dev \
-    python3-pip \
     libpq-dev \
-    netcat \
-  && echo en_GB.UTF-8 UTF-8 > /etc/locale.gen \
-  && locale-gen \
-  && timedatectl set-timezone Europe/London || true \
+    netcat-openbsd \
+    linux-headers \
   && pip3 install -U setuptools pip wheel
-
-RUN apk add --no-cache gcc libc-dev linux-headers
 
 # cache python packages, unless requirements change
 ADD ./requirements requirements
@@ -56,6 +47,9 @@ ENV APPVERSION=${VERSION_NUMBER}
 ENV APP_GIT_COMMIT=${COMMIT_ID}
 ENV APP_BUILD_DATE=${BUILD_DATE}
 ENV APP_BUILD_TAG=${BUILD_TAG}
+
+ENV LC_ALL=en_GB.UTF-8
+ENV TZ=Europe/London
 
 # clearing data to prevent UNIQUE constraint violations when rebuilding locally, at least
 RUN python3 manage.py migrate --no-input \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:focal
+FROM python:3.10-alpine
 
 ENV \
   LANG=en_GB.UTF-8 \
@@ -38,6 +38,8 @@ RUN \
   && locale-gen \
   && timedatectl set-timezone Europe/London || true \
   && pip3 install -U setuptools pip wheel
+
+RUN apk add --no-cache gcc libc-dev linux-headers
 
 # cache python packages, unless requirements change
 ADD ./requirements requirements


### PR DESCRIPTION
#### What

Move from using `ubuntu` (in the form of the `buildpack-deps:focal` image) to `alpine` as our base docker image

#### Ticket

[CFP-260](https://dsdmoj.atlassian.net/browse/CFP-260)

#### Why

`alpine` is smaller and more secure than `ubuntu`. This change results in quicker build times, smaller images, fewer vulnerabilities, and fewer dependencies (reducing the risk of vulnerabilities in future).

|                     | `buildpack-deps:focal` | `3.10-alpine` |
| ----------- | ----------------------- |-------------- |
| Local build time (seconds) | 134 | 91 |
| Resulting image size (mb) | 988 | 315 |
| Vulnerabilities | 104 (46 medium, 58 low) | 0 |
| Dependencies | 409 | 51 |

#### How

Update `dockerfile` replacing `buildpack-deps:focal` with `python:3.10-alpine`.
