### PR TITLE
[CFP-556] Fix linting errors

### DIFF
--- a/fee_calculator/apps/api/serializers.py
+++ b/fee_calculator/apps/api/serializers.py
@@ -9,22 +9,34 @@ from calculator.models import (
 
 
 class SchemeListQuerySerializer(serializers.Serializer):
-    type = serializers.ChoiceField(help_text="Graduated fee scheme type",
-                                   choices=('AGFS', 'LGFS'),
-                                   required=False)
-    case_date = serializers.CharField(help_text="Date for which you would like a list of applicable fee schemes",
-                                      required=False)
+    type = serializers.ChoiceField(
+        help_text="Graduated fee scheme type",
+        choices=('AGFS', 'LGFS'),
+        required=False
+    )
+    case_date = serializers.CharField(
+        help_text="Date for which you would like a list of applicable fee schemes",
+        required=False
+    )
 
 
 class BasePriceFilteredQuerySerializer(serializers.Serializer):
-    scenario = serializers.IntegerField(help_text='',
-                                        required=False,)
-    advocate_type = serializers.CharField(help_text='Note the query will return prices with `advocate_type_id` either matching the value or null.',
-                                          required=False,)
-    offence_class = serializers.CharField(help_text='Note the query will return prices with `offence_class_id` either matching the value or null.',
-                                          required=False,)
-    fee_type_code = serializers.CharField(help_text='',
-                                          required=False,)
+    scenario = serializers.IntegerField(
+        help_text='',
+        required=False,
+    )
+    advocate_type = serializers.CharField(
+        help_text='Note the query will return prices with `advocate_type_id` either matching the value or null.',
+        required=False,
+    )
+    offence_class = serializers.CharField(
+        help_text='Note the query will return prices with `offence_class_id` either matching the value or null.',
+        required=False,
+    )
+    fee_type_code = serializers.CharField(
+        help_text='',
+        required=False,
+    )
 
 
 class CalculatorQuerySerializer(serializers.Serializer):
@@ -46,12 +58,22 @@ class CalculatorQuerySerializer(serializers.Serializer):
             new_kwargs.update(kwargs)
             super().__init__(**new_kwargs)
 
-    scenario = serializers.IntegerField(help_text='', required=True,)
-    fee_type_code = serializers.CharField(help_text='', required=True,)
-    advocate_type = serializers.CharField(help_text='Note the query will return prices with `advocate_type_id` either matching the value or null.',
-                                          required=False,)
-    offence_class = serializers.CharField(help_text='Note the query will return prices with `offence_class_id` either matching the value or null.',
-                                          required=False,)
+    scenario = serializers.IntegerField(
+        help_text='',
+        required=True,
+    )
+    fee_type_code = serializers.CharField(
+        help_text='',
+        required=True,
+    )
+    advocate_type = serializers.CharField(
+        help_text='Note the query will return prices with `advocate_type_id` either matching the value or null.',
+        required=False,
+    )
+    offence_class = serializers.CharField(
+        help_text='Note the query will return prices with `offence_class_id` either matching the value or null.',
+        required=False,
+    )
     case = UnitField('Case')
     day = UnitField('Whole Days')
     defendant = UnitField('Defendants')

--- a/fee_calculator/apps/api/tests/test_fee_type_api.py
+++ b/fee_calculator/apps/api/tests/test_fee_type_api.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITestCase
 from calculator.models import Scheme
 from calculator.tests.lib.utils import prevent_request_warnings
 
+
 class FeeTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/fee-types/'.format(
         api=settings.API_VERSION

--- a/fee_calculator/apps/api/tests/test_modifier_type_api.py
+++ b/fee_calculator/apps/api/tests/test_modifier_type_api.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITestCase
 from calculator.models import Scheme
 from calculator.tests.lib.utils import prevent_request_warnings
 
+
 class ModifierTypeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/modifier-types/'.format(
         api=settings.API_VERSION

--- a/fee_calculator/apps/api/tests/test_price_api.py
+++ b/fee_calculator/apps/api/tests/test_price_api.py
@@ -6,6 +6,7 @@ from rest_framework.test import APITestCase
 
 from calculator.tests.lib.utils import prevent_request_warnings
 
+
 class PriceApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/{{scheme}}/prices/'.format(
         api=settings.API_VERSION

--- a/fee_calculator/apps/api/tests/test_scheme_api.py
+++ b/fee_calculator/apps/api/tests/test_scheme_api.py
@@ -6,6 +6,7 @@ from rest_framework.test import APITestCase
 
 from calculator.tests.lib.utils import prevent_request_warnings
 
+
 class SchemeApiTestCase(APITestCase):
     endpoint = '/api/{api}/fee-schemes/'.format(api=settings.API_VERSION)
 

--- a/fee_calculator/apps/api/urls.py
+++ b/fee_calculator/apps/api/urls.py
@@ -42,4 +42,3 @@ urlpatterns = (
     path('oa3/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='oa3_schema'), name='oa3_swagger-ui'),
     path('docs/', SpectacularSwaggerView.as_view(url_name='oa3_schema')),
 )
-

--- a/fee_calculator/apps/api/views.py
+++ b/fee_calculator/apps/api/views.py
@@ -9,7 +9,6 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from rest_framework import viewsets, views
 from rest_framework.generics import get_object_or_404
-from rest_framework.compat import coreapi
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 

--- a/fee_calculator/apps/calculator/management/commands/generatefees.py
+++ b/fee_calculator/apps/calculator/management/commands/generatefees.py
@@ -112,7 +112,7 @@ class Command(BaseCommand):
             ''')
         )
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # noqa: C901 Ignore Flake8 complexity check
         scheme_name = options['scheme']
 
         scheme_id = {'AGFS10': 3, 'LGFS2016': 2}[scheme_name]
@@ -166,7 +166,7 @@ class Command(BaseCommand):
 
 
 @atomic
-def generate_lgfs_fees(lgfs_scheme, ppe_fees_path, daily_fees_path):
+def generate_lgfs_fees(lgfs_scheme, ppe_fees_path, daily_fees_path):  # noqa: C901 Ignore Flake8 complexity check
     lit_fee_type = FeeType.objects.get(pk=54)
     day_unit = Unit.objects.get(pk='DAY')
     ppe_unit = Unit.objects.get(pk='PPE')
@@ -386,7 +386,7 @@ def generate_lgfs_warrant_fees(scheme_id):
 
 
 @atomic
-def generate_agfs10_fees(agfs_scheme, basic_fees_path, misc_fees_path):
+def generate_agfs10_fees(agfs_scheme, basic_fees_path, misc_fees_path):  # noqa: C901 Ignore Flake8 complexity check
     basic_agfs_fee = FeeType.objects.get(pk=34)
 
     day_unit = Unit.objects.get(pk='DAY')

--- a/fee_calculator/apps/calculator/management/commands/loadbulkdata.py
+++ b/fee_calculator/apps/calculator/management/commands/loadbulkdata.py
@@ -91,12 +91,12 @@ class Command(LoadDataCommand):
                                 ending=''
                             )
                     except (DatabaseError, IntegrityError) as e:
-                            e.args = ("Could not load %(app_label)s.%(object_name)s: %(error_msg)s" % {
-                                'app_label': model._meta.app_label,
-                                'object_name': model._meta.object_name,
-                                'error_msg': force_text(e)
-                            },)
-                            raise
+                        e.args = ("Could not load %(app_label)s.%(object_name)s: %(error_msg)s" % {
+                            'app_label': model._meta.app_label,
+                            'object_name': model._meta.object_name,
+                            'error_msg': force_text(e)
+                        },)
+                        raise
                 else:
                     for obj in objects_to_create:
                         try:

--- a/fee_calculator/apps/calculator/management/commands/loadbulkdata.py
+++ b/fee_calculator/apps/calculator/management/commands/loadbulkdata.py
@@ -15,7 +15,7 @@ from django.utils.encoding import force_text
 
 class Command(LoadDataCommand):
 
-    def load_label(self, fixture_label):
+    def load_label(self, fixture_label):  # noqa: C901 Ignore Flake8 complexity check
         """
         Loads fixtures files for a given label. This method is largely copied
         from django.core.management.commands.loaddata.Command but with the

--- a/fee_calculator/apps/calculator/management/commands/updatecrackedtrial.py
+++ b/fee_calculator/apps/calculator/management/commands/updatecrackedtrial.py
@@ -33,7 +33,13 @@ class Command(BaseCommand):
                          offence_class_id=price.offence_class_id,
                          fixed_fee__gt=0
                          )
-
-                print(f'UPDATING: scheme: {price.scheme_id}, scenario: {price.scenario_id}, fee_type: {price.fee_type_id}, advocate: {price.advocate_type_id}, offence_class_id: {price.offence_class_id}, fixed_fee: {price.fixed_fee} => {new_price.fixed_fee}')
+                print(
+                    f'UPDATING: scheme: {price.scheme_id},'
+                    f'scenario: {price.scenario_id},'
+                    f'fee_type: {price.fee_type_id},'
+                    f'advocate: {price.advocate_type_id},'
+                    f'offence_class_id: {price.offence_class_id},'
+                    f'fixed_fee: {price.fixed_fee} => {new_price.fixed_fee}'
+                )
                 price.fixed_fee = new_price.fixed_fee
                 price.save()

--- a/fee_calculator/apps/calculator/management/commands/updatecrackedtrial.py
+++ b/fee_calculator/apps/calculator/management/commands/updatecrackedtrial.py
@@ -2,9 +2,7 @@
 from django.core.management import BaseCommand
 from django.db.transaction import atomic
 
-from calculator.models import (
-    Scheme, FeeType, Price, Unit
-)
+from calculator.models import Price
 
 
 class Command(BaseCommand):

--- a/fee_calculator/apps/calculator/management/commands/updatecrackedtrial.py
+++ b/fee_calculator/apps/calculator/management/commands/updatecrackedtrial.py
@@ -13,26 +13,27 @@ class Command(BaseCommand):
     '''
 
     def handle(self, *args, **options):
-      with atomic():
-        for price in Price.objects \
-          .extra(
-            select={'offence_class_id_decimal': 'CAST(offence_class_id as DECIMAL)'}
-          ) \
-          .filter(scheme_id=5,
-            scenario_id=3,
-            fee_type_id=34
-          ) \
-          .order_by('offence_class_id_decimal'):
+        with atomic():
+            for price in Price.objects \
+                .extra(
+                    select={
+                        'offence_class_id_decimal': 'CAST(offence_class_id as DECIMAL)'}
+                ) \
+                .filter(scheme_id=5,
+                        scenario_id=3,
+                        fee_type_id=34
+                        ) \
+                    .order_by('offence_class_id_decimal'):
 
-          new_price = Price.objects \
-                        .get(scheme_id=5,
-                          scenario_id=4,
-                          fee_type_id=34,
-                          advocate_type_id=price.advocate_type_id,
-                          offence_class_id=price.offence_class_id,
-                          fixed_fee__gt=0
-                        )
+                new_price = Price.objects \
+                    .get(scheme_id=5,
+                         scenario_id=4,
+                         fee_type_id=34,
+                         advocate_type_id=price.advocate_type_id,
+                         offence_class_id=price.offence_class_id,
+                         fixed_fee__gt=0
+                         )
 
-          print(f'UPDATING: scheme: {price.scheme_id}, scenario: {price.scenario_id}, fee_type: {price.fee_type_id}, advocate: {price.advocate_type_id}, offence_class_id: {price.offence_class_id}, fixed_fee: {price.fixed_fee} => {new_price.fixed_fee}')
-          price.fixed_fee = new_price.fixed_fee
-          price.save()
+                print(f'UPDATING: scheme: {price.scheme_id}, scenario: {price.scenario_id}, fee_type: {price.fee_type_id}, advocate: {price.advocate_type_id}, offence_class_id: {price.offence_class_id}, fixed_fee: {price.fixed_fee} => {new_price.fixed_fee}')
+                price.fixed_fee = new_price.fixed_fee
+                price.save()

--- a/fee_calculator/apps/calculator/management/commands/updatecrackedtrialtests.py
+++ b/fee_calculator/apps/calculator/management/commands/updatecrackedtrialtests.py
@@ -27,7 +27,9 @@ class Command(BaseCommand):
 
         with open(filename, 'r') as csv_file, temp_file:
             reader = csv.DictReader(csv_file)
-            field_names = 'CASE_ID,PERSON_TYPE,BILL_TYPE,BILL_SUB_TYPE,REP_ORD_DATE,BILL_SCENARIO_ID,OFFENCE_CATEGORY,TRIAL_LENGTH,PPE,NO_DEFENDANTS,CALC_FEE_EXC_VAT,CALC_FEE_VAT,THIRD_CRACKED,NUM_OF_WITNESSES,NUM_OF_CASES,QUANTITY,NUM_ATTENDANCE_DAYS,RETRIAL,MONTHS'.split(',')
+            field_names = '''CASE_ID,PERSON_TYPE,BILL_TYPE,BILL_SUB_TYPE,REP_ORD_DATE,BILL_SCENARIO_ID,OFFENCE_CATEGORY,\
+                             TRIAL_LENGTH,PPE,NO_DEFENDANTS,CALC_FEE_EXC_VAT,CALC_FEE_VAT,THIRD_CRACKED,NUM_OF_WITNESSES,\
+                             NUM_OF_CASES,QUANTITY,NUM_ATTENDANCE_DAYS,RETRIAL,MONTHS'''.replace(" ", "").split(',')
             writer = csv.DictWriter(
                 temp_file, fieldnames=field_names, lineterminator='\n')
             writer.writeheader()
@@ -43,7 +45,12 @@ class Command(BaseCommand):
                              fixed_fee__gt=0
                              )
                     print(
-                        f"bill test scenario id: {row['BILL_SCENARIO_ID']}, bill_sub_type: {row['BILL_SUB_TYPE']}, advocate_type_id: {row['PERSON_TYPE']}, offence_class_id: {row['OFFENCE_CATEGORY']}, fixed_fee: {row['CALC_FEE_EXC_VAT']} => {new_price.fixed_fee}")
+                        f"bill test scenario id: {row['BILL_SCENARIO_ID']},"
+                        f"bill_sub_type: {row['BILL_SUB_TYPE']},"
+                        f"advocate_type_id: {row['PERSON_TYPE']},"
+                        f"offence_class_id: {row['OFFENCE_CATEGORY']},"
+                        f"fixed_fee: {row['CALC_FEE_EXC_VAT']} => {new_price.fixed_fee}"
+                    )
 
                     row['REP_ORD_DATE'] = '17/09/2020'
                     row['CALC_FEE_EXC_VAT'] = str(

--- a/fee_calculator/apps/calculator/management/commands/updatecrackedtrialtests.py
+++ b/fee_calculator/apps/calculator/management/commands/updatecrackedtrialtests.py
@@ -18,35 +18,39 @@ class Command(BaseCommand):
     '''
 
     def handle(self, *args, **options):
-      filename = os.path.join(
-          settings.BASE_DIR,
-          'apps/calculator/tests/data/test_dataset_agfs_12.csv'
-      )
+        filename = os.path.join(
+            settings.BASE_DIR,
+            'apps/calculator/tests/data/test_dataset_agfs_12.csv'
+        )
 
-      temp_file = NamedTemporaryFile(delete=False, mode='w')
+        temp_file = NamedTemporaryFile(delete=False, mode='w')
 
-      with open(filename, 'r') as csv_file, temp_file:
-        reader = csv.DictReader(csv_file)
-        field_names = 'CASE_ID,PERSON_TYPE,BILL_TYPE,BILL_SUB_TYPE,REP_ORD_DATE,BILL_SCENARIO_ID,OFFENCE_CATEGORY,TRIAL_LENGTH,PPE,NO_DEFENDANTS,CALC_FEE_EXC_VAT,CALC_FEE_VAT,THIRD_CRACKED,NUM_OF_WITNESSES,NUM_OF_CASES,QUANTITY,NUM_ATTENDANCE_DAYS,RETRIAL,MONTHS'.split(',')
-        writer = csv.DictWriter(temp_file, fieldnames=field_names, lineterminator='\n')
-        writer.writeheader()
+        with open(filename, 'r') as csv_file, temp_file:
+            reader = csv.DictReader(csv_file)
+            field_names = 'CASE_ID,PERSON_TYPE,BILL_TYPE,BILL_SUB_TYPE,REP_ORD_DATE,BILL_SCENARIO_ID,OFFENCE_CATEGORY,TRIAL_LENGTH,PPE,NO_DEFENDANTS,CALC_FEE_EXC_VAT,CALC_FEE_VAT,THIRD_CRACKED,NUM_OF_WITNESSES,NUM_OF_CASES,QUANTITY,NUM_ATTENDANCE_DAYS,RETRIAL,MONTHS'.split(',')
+            writer = csv.DictWriter(
+                temp_file, fieldnames=field_names, lineterminator='\n')
+            writer.writeheader()
 
-        for row in reader:
-          if row['BILL_SCENARIO_ID'] == '2784':
-            new_price = Price.objects \
-                          .get(scheme_id=5,
-                            scenario_id=4,
-                            fee_type_id=34,
-                            advocate_type_id=row['PERSON_TYPE'],
-                            offence_class_id=row['OFFENCE_CATEGORY'],
-                            fixed_fee__gt=0
-                          )
-            print(f"bill test scenario id: {row['BILL_SCENARIO_ID']}, bill_sub_type: {row['BILL_SUB_TYPE']}, advocate_type_id: {row['PERSON_TYPE']}, offence_class_id: {row['OFFENCE_CATEGORY']}, fixed_fee: {row['CALC_FEE_EXC_VAT']} => {new_price.fixed_fee}")
+            for row in reader:
+                if row['BILL_SCENARIO_ID'] == '2784':
+                    new_price = Price.objects \
+                        .get(scheme_id=5,
+                             scenario_id=4,
+                             fee_type_id=34,
+                             advocate_type_id=row['PERSON_TYPE'],
+                             offence_class_id=row['OFFENCE_CATEGORY'],
+                             fixed_fee__gt=0
+                             )
+                    print(
+                        f"bill test scenario id: {row['BILL_SCENARIO_ID']}, bill_sub_type: {row['BILL_SUB_TYPE']}, advocate_type_id: {row['PERSON_TYPE']}, offence_class_id: {row['OFFENCE_CATEGORY']}, fixed_fee: {row['CALC_FEE_EXC_VAT']} => {new_price.fixed_fee}")
 
-            row['REP_ORD_DATE'] = '17/09/2020'
-            row['CALC_FEE_EXC_VAT'] = str(round(new_price.fixed_fee, 0))
-            row['CALC_FEE_VAT'] = str(round(decimal.Decimal('0.2') * new_price.fixed_fee, 2))
+                    row['REP_ORD_DATE'] = '17/09/2020'
+                    row['CALC_FEE_EXC_VAT'] = str(
+                        round(new_price.fixed_fee, 0))
+                    row['CALC_FEE_VAT'] = str(
+                        round(decimal.Decimal('0.2') * new_price.fixed_fee, 2))
 
-          writer.writerow(row)
+                writer.writerow(row)
 
-        shutil.move(temp_file.name, filename)
+            shutil.move(temp_file.name, filename)

--- a/fee_calculator/apps/calculator/management/commands/updatecrackedtrialtests.py
+++ b/fee_calculator/apps/calculator/management/commands/updatecrackedtrialtests.py
@@ -3,16 +3,12 @@ import csv
 import shutil
 import os
 import decimal
-from collections import defaultdict
 from tempfile import NamedTemporaryFile
 
 from django.conf import settings
 from django.core.management import BaseCommand
-from django.db.transaction import atomic
 
-from calculator.models import (
-    Scheme, FeeType, Price, Unit
-)
+from calculator.models import Price
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
#### What
Addresses issues that the `flake8` linter identifies with the existing codebase.

Before: running `python3 -m flake8` lists ~40 code quality issues.
After: running `python3 -m flake8` lists 0 issues.

#### Ticket

[CFP-556](https://dsdmoj.atlassian.net/browse/CFP-556)

#### Why

* To ensure that our code meets quality standards.
* To allow us to subsequently implement linting as part of the CI/CD pipeline.

#### How

Most issues were fixed by using IDE autoformatting. 

Where `flake8` flagged code as being too complex, the issues have been ignored. We may want to refactor these pieces of code individually at a later date.