### PR TITLE
Improve performance of automated test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,13 +132,18 @@ jobs:
       - run:
           name: Split and run tests
           command: |
-            TESTDOTPATHS=$(circleci tests glob "fee_calculator/apps/calculator/tests/**/test_*.py" "fee_calculator/apps/api/tests/**/test_*.py" | sed -e 's|\.py||g' -e 's|/|.|g' | circleci tests split)
+            TESTDOTPATHS=$(circleci tests glob "fee_calculator/apps/calculator/tests/**/test_*.py" "fee_calculator/apps/api/tests/**/test_*.py" | sed 's/\S\+__init__.py//g')
+            echo $TESTDOTPATHS | tr ' ' '\n' | sort | uniq > circleci_test_files.txt
+            TESTDOTPATHS=$(circleci tests split --split-by=timings circleci_test_files.txt)
+            TESTDOTPATHS=$(echo $TESTDOTPATHS | tr "/" "." | sed 's/.py//g')
             venv/bin/python -m coverage run --parallel-mode manage.py test $TESTDOTPATHS --verbosity=1 --noinput
             mv .coverage* tmp/coverage
       - persist_to_workspace:
           root: tmp
           paths:
             - coverage
+      - store_test_results:
+          path: tmp/test-reports
 
   combine_test_coverage:
     executor: cloud-platform-executor

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+tmp/test-reports/
 
 # Translations
 *.mo

--- a/fee_calculator/apps/calculator/tests/__init__.py
+++ b/fee_calculator/apps/calculator/tests/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
-from django.test.runner import DiscoverRunner
+from xmlrunner.extra.djangotestrunner import XMLTestRunner
 
 
-class PreloadDataDiscoverRunner(DiscoverRunner):
+class PreloadDataDiscoverRunner(XMLTestRunner):
 
     def setup_databases(self, **kwargs):
         config = super().setup_databases(**kwargs)

--- a/fee_calculator/apps/calculator/tests/base.py
+++ b/fee_calculator/apps/calculator/tests/base.py
@@ -4,15 +4,16 @@ from decimal import Decimal
 import math
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import SimpleTestCase
 from rest_framework import status
 
 from calculator.tests.lib.utils import scenario_clf_to_id, scenario_ccr_to_id
 from calculator.models import Price, FeeType
 
 
-class CalculatorTestCase(TestCase):
+class CalculatorTestCase(SimpleTestCase):
     scheme_id = NotImplemented
+    databases = ['default']
 
     def endpoint(self):
         return '/api/{version}/fee-schemes/{scheme_id}/calculate/'.format(

--- a/fee_calculator/settings/base.py
+++ b/fee_calculator/settings/base.py
@@ -232,6 +232,7 @@ AUTODISCOVER_HEALTHCHECKS = True
 CORS_ALLOW_ALL_ORIGINS = True
 
 TEST_RUNNER = 'calculator.tests.PreloadDataDiscoverRunner'
+TEST_OUTPUT_DIR = 'tmp/test-reports'
 
 ADMIN_ENABLED = False
 

--- a/requirements/circleci.txt
+++ b/requirements/circleci.txt
@@ -1,3 +1,4 @@
 -r base.txt
 
 coverage>=6.4.1
+unittest-xml-reporting>=3.2.0


### PR DESCRIPTION
#### What
Reduces the runtime of the automated test suite by
1) Making the tests more efficient, and
2) Improving the way CircleCI parallelises tests.

#### Why

To shorten feedback loops and reduce CircleCI costs.

#### How

* Replaces `TestCase` with the more efficient `SimpleTestCase` in the `CalculatorTestCase` class which is inherited from by all other calculator tests. 
* Splits tests for parallel runs based on timings of previous tests rather than arbitrarily by name, resulting in both containers completing in roughly the same amount of time, instead of one taking twice as long as the other. This reduces the elapsed time of the `test` job.

In combination these changes reduce the time taken to run the test suite from approximately 11 minutes to about 4 minutes.