### PR TITLE
[CCP-557] Add flake8 linter to CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,15 @@ commands:
 # JOBS
 # ------------------
 jobs:
+  linting:
+    executor: cloud-platform-executor
+    steps:
+      - checkout
+      - *setup_python_env
+      - run:
+          name: Run flake8
+          command: venv/bin/python -m flake8
+
   test-calculator:
     executor: cloud-platform-executor
     parallelism: 2
@@ -220,12 +229,14 @@ workflows:
     jobs:
       - test-calculator
       - test-viewer
+      - linting
       - combine_test_coverage:
           requires:
             - test-calculator
             - test-viewer
       - build_and_push_image:
           requires:
+            - linting
             - combine_test_coverage
           context:
             - laa-fee-calculator-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,8 @@ jobs:
           root: tmp
           paths:
             - coverage
+      - store_test_results:
+          path: tmp/test-reports
 
   test-viewer:
     executor: cloud-platform-executor
@@ -168,14 +170,11 @@ jobs:
           command: |
             TESTDOTPATHS=$(circleci tests glob "fee_calculator/apps/viewer/tests/**/test_*.py" | sed -e 's|\.py||g' -e 's|/|.|g' | circleci tests split)
             venv/bin/python -m coverage run --parallel-mode manage.py test $TESTDOTPATHS --verbosity=1 --noinput
-            ls .coverage*
             mv .coverage.* tmp/coverage
       - persist_to_workspace:
           root: tmp
           paths:
             - coverage
-      - store_test_results:
-          path: tmp/test-reports
 
   combine_test_coverage:
     executor: cloud-platform-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,6 @@
 version: 2.1
 
 references:
-  setup_python_env: &setup_python_env
-    run:
-      name: Set up python dependencies
-      command: |
-        apk add linux-headers
-        apk add python3-dev
-        `which python3` -m venv venv
-        venv/bin/pip install -U setuptools pip wheel
-        venv/bin/pip install -r requirements/circleci.txt
-
   create-tmp-dir: &create-tmp-dir
     run:
       name: Create workspace temporary directories
@@ -33,6 +23,26 @@ executors:
 # COMMANDS
 # ------------------
 commands:
+  setup_python_env:
+    description: >
+      Install, or restore from cache, python dependencies
+    steps:
+      - restore_cache:
+          keys:
+            - laa-fee-calculator-v1-{{ checksum "requirements/circleci.txt" }}
+      - run:
+          name: Set up python dependencies
+          command: |
+            apk add linux-headers
+            apk add python3-dev
+            `which python3` -m venv venv
+            venv/bin/pip install -U setuptools pip wheel
+            venv/bin/pip install -r requirements/circleci.txt
+      - save_cache:
+          key: laa-fee-calculator-v1-{{ checksum "requirements/circleci.txt" }}
+          paths:
+            - "~/.cache/pip"
+
   build-image:
     description: >
       Build laa-fee-calculator docker image
@@ -122,7 +132,7 @@ jobs:
     executor: cloud-platform-executor
     steps:
       - checkout
-      - *setup_python_env
+      - setup_python_env
       - run:
           name: Run flake8
           command: venv/bin/python -m flake8
@@ -132,12 +142,8 @@ jobs:
     parallelism: 2
     steps:
       - checkout
-      - *setup_python_env
+      - setup_python_env
       - *create-tmp-dir
-      - save_cache:
-          key: laa-fee-calculator-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - ~/project
       - run:
           name: Split and run tests
           command: |
@@ -159,12 +165,8 @@ jobs:
     parallelism: 1
     steps:
       - checkout
-      - *setup_python_env
+      - setup_python_env
       - *create-tmp-dir
-      - save_cache:
-          key: laa-fee-calculator-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - ~/project
       - run:
           name: Split and run tests
           command: |
@@ -179,10 +181,10 @@ jobs:
   combine_test_coverage:
     executor: cloud-platform-executor
     steps:
+      - checkout
+      - setup_python_env
       - attach_workspace:
           at: tmp
-      - restore_cache:
-          key: laa-fee-calculator-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Combine and report on test coverage
           command: |

--- a/fee_calculator/apps/calculator/management/commands/generatefees.py
+++ b/fee_calculator/apps/calculator/management/commands/generatefees.py
@@ -164,9 +164,9 @@ class Command(BaseCommand):
                     options['agfs_10_misc_fees']
                 )
 
-
+# flake8: noqa: C901 Ignore Flake8 complexity check
 @atomic
-def generate_lgfs_fees(lgfs_scheme, ppe_fees_path, daily_fees_path):  # noqa: C901 Ignore Flake8 complexity check
+def generate_lgfs_fees(lgfs_scheme, ppe_fees_path, daily_fees_path):
     lit_fee_type = FeeType.objects.get(pk=54)
     day_unit = Unit.objects.get(pk='DAY')
     ppe_unit = Unit.objects.get(pk='PPE')
@@ -384,9 +384,9 @@ def generate_lgfs_warrant_fees(scheme_id):
     ]:
         clone_prices(base_scenario_id, new_scenario)
 
-
+# flake8: noqa: C901 Ignore Flake8 complexity check
 @atomic
-def generate_agfs10_fees(agfs_scheme, basic_fees_path, misc_fees_path):  # noqa: C901 Ignore Flake8 complexity check
+def generate_agfs10_fees(agfs_scheme, basic_fees_path, misc_fees_path):
     basic_agfs_fee = FeeType.objects.get(pk=34)
 
     day_unit = Unit.objects.get(pk='DAY')

--- a/fee_calculator/apps/viewer/presenters/price_presenters.py
+++ b/fee_calculator/apps/viewer/presenters/price_presenters.py
@@ -1,5 +1,3 @@
-from abc import ABC, abstractmethod
-
 from viewer.presenters.helpers import DelegatorMixin
 
 

--- a/fee_calculator/apps/viewer/presenters/scenario_presenters.py
+++ b/fee_calculator/apps/viewer/presenters/scenario_presenters.py
@@ -105,14 +105,14 @@ class ScenarioPresenter(AbstractScenarioPresenter):
 class InterimScenarioPresenter(ScenarioPresenter):
     @property
     def case_type(self):
-        match = re.search('(?<=- )[^\s]*', self.scenario.name)
+        match = re.search(r'(?<=- )[^\s]*', self.scenario.name)
         return match.group(0).strip().capitalize()
 
 
 class WarrantScenarioPresenter(ScenarioPresenter):
     @property
     def case_type(self):
-        match = re.search('(?<=- )[^\(]*', self.scenario.name)
+        match = re.search(r'(?<=- )[^\(]*', self.scenario.name)
         return match.group(0).strip().capitalize()
 
 


### PR DESCRIPTION
#### What

Adds the `flake8` linter to the CircleCI pipeline. This runs against every build and blocks the pipeline if code quality issues are found.

#### Ticket

[CCP-557](https://dsdmoj.atlassian.net/browse/CFP-557)

#### Why

To maintain the quality of our code.

#### How

* Adds a new `linting` job to the `build-test-and-approval-deploy` CircleCI workflow, which runs `flake8` in parallel with other test jobs.
* Improves the way we cache dependencies in CircleCI by sharing the cache between jobs, reducing the time spent installing dependencies.
* Fixes some issues identified by the linter.

I also looked at doing this as a GitHub Action, but decided it was more coherent to keep all testing/linting processes together. The linting job is quick to complete, and runs in parallel with other jobs, so the impact on CircleCI runtime and costs is minimal.