### PR TITLE
[CFP-561] Remove redundant live-1 hosts

### DIFF
--- a/kubernetes_deploy/live/dev/ingress.yaml
+++ b/kubernetes_deploy/live/dev/ingress.yaml
@@ -12,16 +12,6 @@ metadata:
   namespace: laa-fee-calculator-dev
 spec:
   rules:
-    - host: laa-fee-calculator-dev.apps.live-1.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-        - path: /
-          pathType: Prefix
-          backend:
-            service:
-              name: laa-fee-calculator
-              port:
-                number: 8080
     - host: dev.laa-fee-calculator.service.justice.gov.uk
       http:
         paths:
@@ -33,8 +23,6 @@ spec:
               port:
                 number: 8080
   tls:
-    - hosts:
-      - laa-fee-calculator-dev.apps.live-1.cloud-platform.service.justice.gov.uk
     - hosts:
       - dev.laa-fee-calculator.service.justice.gov.uk
       secretName: laa-fee-calculator-dev-cert

--- a/kubernetes_deploy/live/production/ingress.yaml
+++ b/kubernetes_deploy/live/production/ingress.yaml
@@ -12,16 +12,6 @@ metadata:
   namespace: laa-fee-calculator-production
 spec:
   rules:
-    - host: laa-fee-calculator-production.apps.live-1.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-        - path: /
-          pathType: Prefix
-          backend:
-            service:
-              name: laa-fee-calculator
-              port:
-                number: 8080
     - host: laa-fee-calculator.service.justice.gov.uk
       http:
         paths:
@@ -33,8 +23,6 @@ spec:
               port:
                 number: 8080
   tls:
-    - hosts:
-      - laa-fee-calculator-production.apps.live-1.cloud-platform.service.justice.gov.uk
     - hosts:
       - laa-fee-calculator.service.justice.gov.uk
       secretName: laa-fee-calculator-production-cert

--- a/kubernetes_deploy/live/staging/ingress.yaml
+++ b/kubernetes_deploy/live/staging/ingress.yaml
@@ -12,16 +12,6 @@ metadata:
   namespace: laa-fee-calculator-staging
 spec:
   rules:
-    - host: laa-fee-calculator-staging.apps.live-1.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-        - path: /
-          pathType: Prefix
-          backend:
-            service:
-              name: laa-fee-calculator
-              port:
-                number: 8080
     - host: staging.laa-fee-calculator.service.justice.gov.uk
       http:
         paths:
@@ -33,8 +23,6 @@ spec:
               port:
                 number: 8080
   tls:
-    - hosts:
-      - laa-fee-calculator-staging.apps.live-1.cloud-platform.service.justice.gov.uk
     - hosts:
       - staging.laa-fee-calculator.service.justice.gov.uk
       secretName: laa-fee-calculator-staging-cert


### PR DESCRIPTION
#### What

Post EKS-migration, Fee Calculator deploys to `dev`, `staging` and `production` with two hosts, one in the format `laa-fee-calculator-*.apps.live-1.cloud-platform.service.justice.gov.uk` and the other in the format `*.laa-fee-calculator.service.justice.gov.uk`.

The first of these is redundant, and is being flagged by the Cloud Platform team as an infringement: https://reports.cloud-platform.service.justice.gov.uk/live_1_domains.

#### Ticket

[CFP-561](https://dsdmoj.atlassian.net/browse/CFP-561)

#### Why

To remove technical debt and keep the Cloud Platform team happy.

#### How

Remove the config for the redundant hosts from the relevant ingress file for each environment.

Tested by deploying to `dev` and `staging` and testing via the respective CCCD environments.