### PR TITLE
Bump django-filter to v21.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ drf-spectacular==0.22.1
 djangorestframework>=3.12,<3.14.0
 django-extended-choices==1.3.3
 django-cors-headers==3.13.0
-django-filter==2.4.0
+django-filter==21.1.0
 drf-nested-routers==0.93.4
 flake8==4.0.1
 pyyaml>=4.2b1


### PR DESCRIPTION
#### What

The dependabot update to bump `django-filter` to v22.1 is failing. As an interim step, move to v21.1.
