### PR TITLE
[SPIKE] CFP-580 Update k8s config to use ingress v1.2

### DIFF
--- a/kubernetes_deploy/live/dev/ingress.yaml
+++ b/kubernetes_deploy/live/dev/ingress.yaml
@@ -4,13 +4,13 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
   name: laa-fee-calculator
   namespace: laa-fee-calculator-dev
 spec:
+  ingressClassName: modsec
   rules:
     - host: dev.laa-fee-calculator.service.justice.gov.uk
       http:

--- a/kubernetes_deploy/live/production/ingress.yaml
+++ b/kubernetes_deploy/live/production/ingress.yaml
@@ -4,13 +4,13 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
   name: laa-fee-calculator
   namespace: laa-fee-calculator-production
 spec:
+  ingressClassName: modsec
   rules:
     - host: laa-fee-calculator.service.justice.gov.uk
       http:

--- a/kubernetes_deploy/live/staging/ingress.yaml
+++ b/kubernetes_deploy/live/staging/ingress.yaml
@@ -4,13 +4,13 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
   name: laa-fee-calculator
   namespace: laa-fee-calculator-staging
 spec:
+  ingressClassName: modsec
   rules:
     - host: staging.laa-fee-calculator.service.justice.gov.uk
       http:


### PR DESCRIPTION
#### What

Cloud Platform team require us to move to v1.2 of the k8s ingress. This commit makes the config changes needed to do this, for all three environments.

This PR can be deployed to dev and staging, however it will result in the service being unavailable for a short time (< 1 minute) and so the [zero-downtime approach](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/Switch-ingress-to-v1-ingress-controller.html#switch-to-the-new-ingress-controller-with-zero-downtime) to making these changes should be followed for deploying to production.

#### Ticket

[CFP-580](link)

#### Why

The old ingress will soon be unsupported and this change is necessary to stay within support and secure.

#### How

For the `dev`, `staging`, and `production` `ingress.yaml` files:

* Remove the `kubernetes.io/ingress.class` annotation
* Add the `ingressClassName` field with a value of `modsec`
