### PR TITLE
Update alpine packages in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN addgroup --gid 1000 --system appgroup \
 # setup environment
 RUN \
   set -ex \
-  && apk update \
+  && apk --update-cache upgrade \
   && apk add \
     --virtual \
     tzdata \


### PR DESCRIPTION
#### What

Ensure all packages in docker images are updated to their latest versions.

#### Why

Executes `apk --update-cache upgrade` instead of `apk update` when the
docker image is built to ensure the most recent versions of all packages
are used.

This will address two security issues ([1](https://github.com/ministryofjustice/laa-fee-calculator/security/code-scanning/1222), [2](https://github.com/ministryofjustice/laa-fee-calculator/security/code-scanning/1223)) with dependencies which have been fixed in the alpine image but not picked up by our build.

<img width="406" alt="image" src="https://user-images.githubusercontent.com/28729201/183598198-807913a8-139c-4055-accb-f7f07b78189c.png">
