### PR TITLE
Pin some dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,13 +1,13 @@
-Django>=3.2,<4.1
+Django==3.2.15
 django-moj-irat==0.7
 drf-spectacular==0.23.1
-djangorestframework>=3.12,<3.14.0
+djangorestframework==3.13.1
 django-extended-choices==1.3.3
 django-cors-headers==3.13.0
 django-filter==21.1.0
 drf-nested-routers==0.93.4
 flake8==4.0.1
-pyyaml>=4.2b1
+pyyaml==6.0
 six==1.16.0
 uWSGI==2.0.20
-sentry-sdk>=1.5.4
+sentry-sdk==1.9.2


### PR DESCRIPTION
#### What

Fix the exact versions of some dependencies to avoid possible issues with updates.

#### Ticket

N/A

#### Why

An unnecessarily loose dependency version requirement may allow newer versions of libraries to be use in the production environment than are being used in development. This could result in some issues being hidden.

Specifically, we currently allow either version 3.2 or 4.0 of Django but `django-moj-irat` is fixing it to 3.2. An update to `django-moj-irat` may therefore unexpectedly upgrade Django.

Dependabot will open PRs when new versions of libraries become available so that they can be reviewed.

#### How

* Django fixed to 3.2.15. 3.2 is a long term support version.
* djangorestframework fixed to 3.13.1.
* pyyaml fixed to 6.0.
* sentry-sdk fixed to 1.9.2.

These are all the versions that are currently used in production and, with the exception of Django, they are also the latest versions available.