### PR TITLE
TEMP: Set CLAIR start dates to 01/06/2022 for testing

### DIFF
--- a/fee_calculator/apps/calculator/fixtures/scheme.json
+++ b/fee_calculator/apps/calculator/fixtures/scheme.json
@@ -14,7 +14,7 @@
     "pk": 2,
     "fields": {
       "start_date": "2016-04-01",
-      "end_date": "2022-09-29",
+      "end_date": "2022-05-31",
       "base_type": 2,
       "description": "LGFS Fee Scheme 2016-04"
     }
@@ -44,7 +44,7 @@
     "pk": 5,
     "fields": {
       "start_date": "2020-09-17",
-      "end_date": "2022-09-29",
+      "end_date": "2022-05-31",
       "base_type": 1,
       "description": "AGFS Fee Scheme 12 - CLAR accelerated measures"
     }
@@ -53,7 +53,7 @@
     "model": "calculator.scheme",
     "pk": 6,
     "fields": {
-      "start_date": "2022-09-30",
+      "start_date": "2022-06-01",
       "end_date": null,
       "base_type": 2,
       "description": "LGFS Fee Scheme 10 (2022-09 - CLAIR)"
@@ -63,7 +63,7 @@
     "model": "calculator.scheme",
     "pk": 7,
     "fields": {
-      "start_date": "2022-09-30",
+      "start_date": "2022-06-01",
       "end_date": null,
       "base_type": 1,
       "description": "AGFS Fee Scheme 13 (2022-09 - CLAIR)"


### PR DESCRIPTION
#### What

A temporary change to set the start dates of the LGFS and AGFS  CLAIR fee schemes 01/06/2022 to allow integration testing with CCR and CCLF.

This should only be deployed to the `staging` environment.
