### PR TITLE
CFP-579 Update ingress controllers to v1.2

### DIFF
--- a/kubernetes_deploy/live/dev/ingress.yaml
+++ b/kubernetes_deploy/live/dev/ingress.yaml
@@ -2,15 +2,15 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-dev-green
+    external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-v1-laa-fee-calculator-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-  name: laa-fee-calculator
+  name: laa-fee-calculator-v1
   namespace: laa-fee-calculator-dev
 spec:
+  ingressClassName: modsec
   rules:
     - host: dev.laa-fee-calculator.service.justice.gov.uk
       http:

--- a/kubernetes_deploy/live/production/ingress.yaml
+++ b/kubernetes_deploy/live/production/ingress.yaml
@@ -2,15 +2,15 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-v1-laa-fee-calculator-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-  name: laa-fee-calculator
+  name: laa-fee-calculator-v1
   namespace: laa-fee-calculator-production
 spec:
+  ingressClassName: modsec
   rules:
     - host: laa-fee-calculator.service.justice.gov.uk
       http:

--- a/kubernetes_deploy/live/staging/ingress.yaml
+++ b/kubernetes_deploy/live/staging/ingress.yaml
@@ -2,15 +2,15 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-laa-fee-calculator-staging-green
+    external-dns.alpha.kubernetes.io/set-identifier: laa-fee-calculator-v1-laa-fee-calculator-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-  name: laa-fee-calculator
+  name: laa-fee-calculator-v1
   namespace: laa-fee-calculator-staging
 spec:
+  ingressClassName: modsec
   rules:
     - host: staging.laa-fee-calculator.service.justice.gov.uk
       http:


### PR DESCRIPTION
**What**
Update ingress controllers to v1.2

**Ticket**
[CFP-580](https://dsdmoj.atlassian.net/browse/CFP-580)

**Why**
To comply with Cloud Platform requirements, remain in service, and benefit from improved security and logging.

**How**
Updates kubernetes configuration for all three environments to use v1.2 of the ingress controller. This has been applied using the zero-downtime guidance provided by the Cloud Platform team: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html#introduction. 

The changes here are slightly simpler than for CCCD as some steps have already been taken in a previous [commit](https://github.com/ministryofjustice/laa-fee-calculator/commit/5d261861b45e7e1cbbd3d6b022f3f4bbf7598b15).

This PR tidies up the configuration in code so that future deployments will be consistent.