### PR TITLE
Update deprecated GitHub Action

### DIFF
--- a/.github/workflows/docker_image_scan.yml
+++ b/.github/workflows/docker_image_scan.yml
@@ -39,7 +39,7 @@ jobs:
         args: --file=Dockerfile
 
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: snyk.sarif
 


### PR DESCRIPTION
#### What

The GitHub CodeQL Action v1 will be deprecated in December 2022. This is used in the `docker_image_scan` job which runs nightly to scan our docker images with Snyk.

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/28729201/195070839-76e627bb-a356-44af-b0c5-b33a6115aaa5.png">

https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

#### How

Replace `github/codeql-action/upload-sarif@v1` in the affected workflow with `github/codeql-action/upload-sarif@v2`.

