### PR TITLE
Use Dependabot to manage GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,15 @@ updates:
   open-pull-requests-limit: 10
   rebase-strategy: "disabled"
   reviewers:
-  - "mpw5"
-  - "jrmhaig"
+  - "ministryofjustice/laa-claim-for-payment"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: thursday
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  rebase-strategy: "disabled"
+  reviewers:
+  - "ministryofjustice/laa-claim-for-payment"


### PR DESCRIPTION
#### What

Dependabot can be used to ensure that GitHub Actions are kept up to date: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

As a result, manual PRs such as https://github.com/ministryofjustice/laa-fee-calculator/pull/273 will be unnecessary.

#### How

This adds the necessary configuration to `.github/dependabot.yml`,  replicating our dependabot setup for other dependencies.

It also makes a minor change to `pip` updates, adding the `laa-claim-for-payment-team` as reviewers instead of named individuals - this will make on/off-boarding easier in future.