### PR TITLE
Test that only one fee scheme is returned

### DIFF
--- a/fee_calculator/apps/api/tests/test_scheme_api.py
+++ b/fee_calculator/apps/api/tests/test_scheme_api.py
@@ -32,6 +32,7 @@ class SchemeApiTestCase(APITestCase):
     def test_get_by_date_available(self):
         response = self.client.get('%s?type=AGFS&case_date=2012-04-02' % self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['id'], 1)
 
     @prevent_request_warnings


### PR DESCRIPTION
#### What

Update the test for looking up a fee scheme to check that only a single item is returned.

#### Ticket

N/A

#### Why

The search `?type=AGFS&case_date=2012-04-02` only returns a single fee scheme but the test only checks that the first element returned is the correct one. As it happens a wider search, such as `?type=AGFS` will also return the same scheme as the first element so this test could still pass if the filter is broken.

#### How

```python
self.assertEqual(len(response.data['results']), 1)
```
