### PR TITLE
Fix syntax in CODEOWNERS to allow multiple teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @ministryofjustice/laa-claim-for-payment
-* @ministryofjustice/laa-clair-taskforce
+* @ministryofjustice/laa-claim-for-payment @ministryofjustice/laa-clair-taskforce


### PR DESCRIPTION
#### What

Fix syntax in CODEOWNERS to allow multiple teams

#### Why

Current syntax requires an approving review from `laa-clair-taskforce`. Members of `laa-claim-for-payment` should also be able to approve.
