### PR TITLE
Update circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,11 +226,71 @@ jobs:
 # ------------------
 workflows:
   version: 2
+  build-and-test:
+    jobs:
+      - test-calculator:
+          filters:
+            branches:
+              ignore:
+                - master
+      - test-viewer:
+          filters:
+            branches:
+              ignore:
+                - master
+      - linting:
+          filters:
+            branches:
+              ignore:
+                - master
+      - combine_test_coverage:
+          requires:
+            - test-calculator
+            - test-viewer
+      - build_and_push_approval:
+          type: approval
+      - build_and_push_image:
+          context:
+            - laa-fee-calculator-base
+          requires:
+            - build_and_push_approval
+      - dev_deploy_approval:
+          type: approval
+          requires:
+            - build_and_push_image
+      - dev_deploy:
+          requires:
+            - dev_deploy_approval
+          context:
+            - laa-fee-calculator-base
+            - laa-fee-calculator-live-dev
+      - staging_deploy_approval:
+          type: approval
+          requires:
+            - build_and_push_image
+      - staging_deploy:
+          requires:
+            - staging_deploy_approval
+          context:
+            - laa-fee-calculator-base
+            - laa-fee-calculator-live-staging
   build-test-and-approval-deploy:
     jobs:
-      - test-calculator
-      - test-viewer
-      - linting
+      - test-calculator:
+          filters:
+            branches:
+              only:
+                - master
+      - test-viewer:
+          filters:
+            branches:
+              only:
+                - master
+      - linting:
+          filters:
+            branches:
+              only:
+                - master
       - combine_test_coverage:
           requires:
             - test-calculator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - run:
           name: Split and run tests
           command: |
-            TESTDOTPATHS=$(circleci tests glob "fee_calculator/apps/calculator/tests/**/test_*.py" "fee_calculator/apps/api/tests/**/test_*.py" | sed 's/\S\+__init__.py//g')
+            TESTDOTPATHS=$(circleci tests glob "fee_calculator/apps/calculator/tests/**/test_*.py" | sed 's/\S\+__init__.py//g')
             echo $TESTDOTPATHS | tr ' ' '\n' | sort | uniq > circleci_test_files.txt
             TESTDOTPATHS=$(circleci tests split --split-by=timings circleci_test_files.txt)
             TESTDOTPATHS=$(echo $TESTDOTPATHS | tr "/" "." | sed 's/.py//g')
@@ -160,7 +160,7 @@ jobs:
       - store_test_results:
           path: tmp/test-reports
 
-  test-viewer:
+  test-viewer-and-api:
     executor: cloud-platform-executor
     parallelism: 1
     steps:
@@ -170,7 +170,7 @@ jobs:
       - run:
           name: Split and run tests
           command: |
-            TESTDOTPATHS=$(circleci tests glob "fee_calculator/apps/viewer/tests/**/test_*.py" | sed -e 's|\.py||g' -e 's|/|.|g' | circleci tests split)
+            TESTDOTPATHS=$(circleci tests glob "fee_calculator/apps/viewer/tests/**/test_*.py" "fee_calculator/apps/api/tests/**/test_*.py" | sed -e 's|\.py||g' -e 's|/|.|g' | circleci tests split)
             venv/bin/python -m coverage run --parallel-mode manage.py test $TESTDOTPATHS --verbosity=1 --noinput
             mv .coverage.* tmp/coverage
       - persist_to_workspace:
@@ -233,7 +233,7 @@ workflows:
             branches:
               ignore:
                 - master
-      - test-viewer:
+      - test-viewer-and-api:
           filters:
             branches:
               ignore:
@@ -246,7 +246,7 @@ workflows:
       - combine_test_coverage:
           requires:
             - test-calculator
-            - test-viewer
+            - test-viewer-and-api
       - build_and_push_approval:
           type: approval
       - build_and_push_image:
@@ -281,7 +281,7 @@ workflows:
             branches:
               only:
                 - master
-      - test-viewer:
+      - test-viewer-and-api:
           filters:
             branches:
               only:
@@ -294,7 +294,7 @@ workflows:
       - combine_test_coverage:
           requires:
             - test-calculator
-            - test-viewer
+            - test-viewer-and-api
       - build_and_push_image:
           requires:
             - linting


### PR DESCRIPTION
#### What

Create a new test workflow in the CircleCI configuration.

#### Ticket

N/A

#### Why

Currently we only have a single workflow in CircleCI that is run for all branches. This is used both for testing branches and for deploying to production, with the final steps only permitted for the master branch. The implications of this when testing branches are;

* the image cannot be built until all tests and linting pass
* it is not possible to deploy to the staging environment without first deploying to the dev environment

#### How

Create a new workflow based on the existing `build-test-and-approval-deploy` workflow with the following changes;

* Run on all branches except master
* Do not require the tests or linting jobs to pass before building an image
* Add an approval step for the building of the image
* Do not include steps to deploy to production

Additionally, only run the `build-test-and-approval-deploy` workflow on the master branch.

The testing pipeline looks like;

![Screenshot 2022-10-19 at 13 50 10](https://user-images.githubusercontent.com/4415912/196695674-a1a8edc4-1baa-465e-8822-67e25e90174b.png)
