### PR TITLE
Use django_filters for schemes

### DIFF
--- a/fee_calculator/apps/api/tests/test_filters.py
+++ b/fee_calculator/apps/api/tests/test_filters.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from calculator.models import Scheme
+from calculator.constants import SCHEME_TYPE
+from api.filters import SchemeFilter
+
+NUMBER_OF_AGFS_SCHEMES = 5
+NUMBER_OF_LGFS_SCHEMES = 2
+
+
+class SchemeFilterTestCase(TestCase):
+    @classmethod
+    def setUp(cls):
+        cls.allSchemes = Scheme.objects.all()
+
+    def test_filter_for_agfs_type(self):
+        schemes = SchemeFilter(data={'type': 'AGFS'}, queryset=self.allSchemes).qs
+        self.assertEqual(len(schemes), NUMBER_OF_AGFS_SCHEMES)
+        self.assertEqual({s.base_type for s in schemes}, {SCHEME_TYPE.for_constant('AGFS').value})
+
+    def test_filter_for_lgfs_type(self):
+        schemes = SchemeFilter(data={'type': 'LGFS'}, queryset=self.allSchemes).qs
+        self.assertEqual(len(schemes), NUMBER_OF_LGFS_SCHEMES)
+        self.assertEqual({s.base_type for s in schemes}, {SCHEME_TYPE.for_constant('LGFS').value})
+
+    def test_filter_for_case_date(self):
+        schemes = SchemeFilter(data={'case_date': '2020-06-06'}, queryset=self.allSchemes).qs
+        self.assertEqual(len(schemes), 2)
+        self.assertEqual({s.pk for s in schemes}, {2, 4})
+
+    def test_filter_for_type_and_case_date(self):
+        schemes = SchemeFilter(data={'type': 'AGFS', 'case_date': '2020-06-06'}, queryset=self.allSchemes).qs
+        self.assertEqual(len(schemes), 1)
+        self.assertEqual(schemes.first().pk, 4)


### PR DESCRIPTION
#### What

Use `django_filters` for filtering schemes fetched by `/api/v1/fee-schemes/` and `/api/v1/fee-schemes/<id>`.

#### Ticket

N/A

#### Why

Some of the filtering in the views in `fee_calculator/apps/api/views.py` is done in the views class and some is done in filters defined with `django_filters` in `fee_calculator/apps/api/filters.py`.

* For consistency, one method would ideally be used in all cases.
* For better separation of concerns, filters would be moved into the filters classes.
* It is likely that we will soon be modifying the fee scheme filtering. This change in intended to clean it up in advance.

#### How

Create a `SchemeFilter` class to be used by `SchemeViewSet` with rules to filter `type` and `case_date`.

#### Note

Errors are now handled by `django_filters`, instead of raising exceptions, so before an incorrectly formatted date would get:

```bash
% curl -X 'GET' \
  'https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2%20January%202021&type=AGFS' \
  -H 'accept: application/json'
["`case_date` should be in the format YYYY-MM-DD"]%
```

but now it gets

```bash
% curl -X 'GET' \
  'https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2%20January%202021&type=AGFS' \
  -H 'accept: application/json'
{"case_date":["Enter a valid date."]}%
```

Both of these get a 400 status.