### PR TITLE
CTSKF-39 Allow main_hearing_date parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For development setup see instructions [here](./docs/DEVELOPMENT.md)
 
 Swagger docs are accessible at `/api/v1/docs/`
 
-First request `/api/v1/fee-schemes/?type=<type>&case_date=<case_date>` to get the appropriate scheme.
+First request `/api/v1/fee-schemes/?type=<type>&case_date=<representation_order_date>&main_hearing_date=<main_hearing_date>` to get the appropriate scheme.
 
 Then request:
 

--- a/fee_calculator/apps/api/serializers.py
+++ b/fee_calculator/apps/api/serializers.py
@@ -15,7 +15,11 @@ class SchemeListQuerySerializer(serializers.Serializer):
         required=False
     )
     case_date = serializers.CharField(
-        help_text="Date for which you would like a list of applicable fee schemes",
+        help_text="Representation order date for which you would like a list of applicable fee schemes",
+        required=False
+    )
+    main_hearing_date = serializers.CharField(
+        help_text="Main hearing date for which you would like a list of applicable fee schemes",
         required=False
     )
 

--- a/fee_calculator/apps/api/tests/test_scheme_api.py
+++ b/fee_calculator/apps/api/tests/test_scheme_api.py
@@ -39,3 +39,15 @@ class SchemeApiTestCase(APITestCase):
     def test_400_on_invalid_date(self):
         response = self.client.get('%s?type=AGFS&case_date=4thJanuary2015' % self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_by_case_date_and_main_hearing_date(self):
+        response = self.client.get('%s?type=AGFS&case_date=2012-04-02&main_hearing_date=2012-04-02' % self.endpoint)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['id'], 1)
+
+    def test_get_by_case_date_and_null_main_hearing_date(self):
+        response = self.client.get('%s?type=AGFS&case_date=2012-04-02&main_hearing_date=' % self.endpoint)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['id'], 1)


### PR DESCRIPTION
#### What

Allows the inclusion of the main hearing date of a claim as a parameter in GET requests made to Fee Calculator to using the `/api/v1/fee-schemes/` endpoint.

#### Ticket

[CTSKF-39](https://dsdmoj.atlassian.net/browse/CTSKF-39)

#### Why

To allow the selection of CLAIR interim fee schemes based on main hearing date in addition to representation order date.

#### How

* Adds `main_hearing_date` as an optional parameter in the `SchemeListQuerySerializer` class.
* Clarifies the meaning of the case date (which is essentially the representation order date).
* Adds extra tests.
* Updates the README.