### PR TITLE
[CTSKF-38] Show main hearing date on FeeScheme Viewer pages

### DIFF
--- a/fee_calculator/apps/viewer/templates/viewer/fee_scheme/_summary.html
+++ b/fee_calculator/apps/viewer/templates/viewer/fee_scheme/_summary.html
@@ -16,12 +16,8 @@
       <td class="govuk-table__cell">{{ scheme.end_date|default_if_none:"Present" }}</td>
     </tr>
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Main hearing start date</th>
-      <td class="govuk-table__cell">{{ scheme.main_hearing_start_date|default_if_none:"Present" }}</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Main hearing end date</th>
-      <td class="govuk-table__cell">{{ scheme.main_hearing_end_date|default_if_none:"Present" }}</td>
+      <th scope="row" class="govuk-table__header">Earliest main hearing date</th>
+      <td class="govuk-table__cell">{{ scheme.earliest_main_hearing_date|default_if_none:"Present" }}</td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Offence class</th>

--- a/fee_calculator/apps/viewer/templates/viewer/fee_scheme/_summary.html
+++ b/fee_calculator/apps/viewer/templates/viewer/fee_scheme/_summary.html
@@ -16,6 +16,14 @@
       <td class="govuk-table__cell">{{ scheme.end_date|default_if_none:"Present" }}</td>
     </tr>
     <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Main hearing start date</th>
+      <td class="govuk-table__cell">{{ scheme.main_hearing_start_date|default_if_none:"Present" }}</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Main hearing end date</th>
+      <td class="govuk-table__cell">{{ scheme.main_hearing_end_date|default_if_none:"Present" }}</td>
+    </tr>
+    <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Offence class</th>
       <td class="govuk-table__cell">{{ scheme.selected_offence_class.display_name }}</td>
     </tr>

--- a/fee_calculator/apps/viewer/templates/viewer/fee_scheme/_summary.html
+++ b/fee_calculator/apps/viewer/templates/viewer/fee_scheme/_summary.html
@@ -17,7 +17,7 @@
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Earliest main hearing date</th>
-      <td class="govuk-table__cell">{{ scheme.earliest_main_hearing_date|default_if_none:"Present" }}</td>
+      <td class="govuk-table__cell">{{ scheme.earliest_main_hearing_date|default_if_none:"-" }}</td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Offence class</th>

--- a/fee_calculator/apps/viewer/templates/viewer/fee_schemes.html
+++ b/fee_calculator/apps/viewer/templates/viewer/fee_schemes.html
@@ -21,6 +21,8 @@ Fee Schemes
       <th scope="col" class="govuk-table__header">Base</th>
       <th scope="col" class="govuk-table__header">Start Date</th>
       <th scope="col" class="govuk-table__header">End Date</th>
+      <th scope="col" class="govuk-table__header">Main Hearing Start Date</th>
+      <th scope="col" class="govuk-table__header">Main Hearing End Date</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -38,6 +40,8 @@ Fee Schemes
       </td>
       <td class="govuk-table__cell">{{ scheme.start_date }}</td>
       <td class="govuk-table__cell">{{ scheme.end_date|default_if_none:"Present" }}</td>
+      <td class="govuk-table__cell">{{ scheme.main_hearing_start_date|default_if_none:"Present" }}</td>
+      <td class="govuk-table__cell">{{ scheme.main_hearing_end_date|default_if_none:"Present" }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/fee_calculator/apps/viewer/templates/viewer/fee_schemes.html
+++ b/fee_calculator/apps/viewer/templates/viewer/fee_schemes.html
@@ -21,8 +21,7 @@ Fee Schemes
       <th scope="col" class="govuk-table__header">Base</th>
       <th scope="col" class="govuk-table__header">Start Date</th>
       <th scope="col" class="govuk-table__header">End Date</th>
-      <th scope="col" class="govuk-table__header">Main Hearing Start Date</th>
-      <th scope="col" class="govuk-table__header">Main Hearing End Date</th>
+      <th scope="col" class="govuk-table__header">Earliest Main Hearing Date</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -40,8 +39,7 @@ Fee Schemes
       </td>
       <td class="govuk-table__cell">{{ scheme.start_date }}</td>
       <td class="govuk-table__cell">{{ scheme.end_date|default_if_none:"Present" }}</td>
-      <td class="govuk-table__cell">{{ scheme.main_hearing_start_date|default_if_none:"Present" }}</td>
-      <td class="govuk-table__cell">{{ scheme.main_hearing_end_date|default_if_none:"Present" }}</td>
+      <td class="govuk-table__cell">{{ scheme.earliest_main_hearing_date|default_if_none:"Present" }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/fee_calculator/apps/viewer/templates/viewer/fee_schemes.html
+++ b/fee_calculator/apps/viewer/templates/viewer/fee_schemes.html
@@ -39,7 +39,7 @@ Fee Schemes
       </td>
       <td class="govuk-table__cell">{{ scheme.start_date }}</td>
       <td class="govuk-table__cell">{{ scheme.end_date|default_if_none:"Present" }}</td>
-      <td class="govuk-table__cell">{{ scheme.earliest_main_hearing_date|default_if_none:"Present" }}</td>
+      <td class="govuk-table__cell">{{ scheme.earliest_main_hearing_date|default_if_none:"-" }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/fee_calculator/apps/viewer/tests/presenters/test_scheme_presenters.py
+++ b/fee_calculator/apps/viewer/tests/presenters/test_scheme_presenters.py
@@ -39,7 +39,7 @@ class SchemePresenterTestCase(TestCase):
     @classmethod
     def setUp(self):
         self.default_kwargs = {'base_type': 1, 'start_date': '2022-03-05',
-                               'main_hearing_start_date': '2022-03-05', 'main_hearing_end_date': None}
+                               'earliest_main_hearing_date': '2022-03-05'}
         self.presenter_options = {}
 
     def test_base_type_agfs(self):
@@ -58,5 +58,4 @@ class SchemePresenterTestCase(TestCase):
         self.default_kwargs['base_type'] = 1
         scenario = Scheme.objects.create(**self.default_kwargs)
         presenter = SchemePresenter(scenario, **self.presenter_options)
-        self.assertEqual(presenter.main_hearing_start_date, '2022-03-05')
-        self.assertEqual(presenter.main_hearing_end_date, None)
+        self.assertEqual(presenter.earliest_main_hearing_date, '2022-03-05')

--- a/fee_calculator/apps/viewer/tests/presenters/test_scheme_presenters.py
+++ b/fee_calculator/apps/viewer/tests/presenters/test_scheme_presenters.py
@@ -38,7 +38,8 @@ class SchemePresenterFactoryTestCase(TestCase):
 class SchemePresenterTestCase(TestCase):
     @classmethod
     def setUp(self):
-        self.default_kwargs = {'base_type': 1, 'start_date': '2022-03-05'}
+        self.default_kwargs = {'base_type': 1, 'start_date': '2022-03-05',
+                               'main_hearing_start_date': '2022-03-05', 'main_hearing_end_date': None}
         self.presenter_options = {}
 
     def test_base_type_agfs(self):
@@ -52,3 +53,10 @@ class SchemePresenterTestCase(TestCase):
         scenario = Scheme.objects.create(**self.default_kwargs)
         presenter = SchemePresenter(scenario, **self.presenter_options)
         self.assertEqual(presenter.base_type, 'LGFS')
+
+    def test_main_hearing_date(self):
+        self.default_kwargs['base_type'] = 1
+        scenario = Scheme.objects.create(**self.default_kwargs)
+        presenter = SchemePresenter(scenario, **self.presenter_options)
+        self.assertEqual(presenter.main_hearing_start_date, '2022-03-05')
+        self.assertEqual(presenter.main_hearing_end_date, None)

--- a/fee_calculator/apps/viewer/tests/test_views.py
+++ b/fee_calculator/apps/viewer/tests/test_views.py
@@ -23,6 +23,14 @@ class FeeSchemeTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'viewer/fee_scheme.html')
 
+    def test_display_main_hearing_date(self):
+        Scheme.objects.create(id=9999, start_date='2022-06-15', base_type=1,
+                              main_hearing_start_date='2022-11-01', main_hearing_end_date='2022-12-01')
+        response = self.client.get('/viewer/fee_schemes/9999')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<td class="govuk-table__cell">Nov. 1, 2022</td>', html=True)
+        self.assertContains(response, '<td class="govuk-table__cell">Dec. 1, 2022</td>', html=True)
+
     def test_404_for_an_unkonwn_fee_scheme(self):
         response = self.client.get('/viewer/fee_schemes/9999')
         self.assertEqual(response.status_code, 404)

--- a/fee_calculator/apps/viewer/tests/test_views.py
+++ b/fee_calculator/apps/viewer/tests/test_views.py
@@ -25,11 +25,10 @@ class FeeSchemeTestCase(TestCase):
 
     def test_display_main_hearing_date(self):
         Scheme.objects.create(id=9999, start_date='2022-06-15', base_type=1,
-                              main_hearing_start_date='2022-11-01', main_hearing_end_date='2022-12-01')
+                              earliest_main_hearing_date='2022-11-01')
         response = self.client.get('/viewer/fee_schemes/9999')
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<td class="govuk-table__cell">Nov. 1, 2022</td>', html=True)
-        self.assertContains(response, '<td class="govuk-table__cell">Dec. 1, 2022</td>', html=True)
 
     def test_404_for_an_unkonwn_fee_scheme(self):
         response = self.client.get('/viewer/fee_schemes/9999')


### PR DESCRIPTION
#### What

- Update the viewer package templates to show the `earliest_main_hearing_date` on the `/fee_schemes` and the `/fee_schemes/{pk}` pages

- Update unit tests


#### Ticket

[CTSKF-38](https://dsdmoj.atlassian.net/browse/CTSKF-38)


#### TODO

- [ ] The column names overlap on the /fee_schemes page, is that ok?
- [ ] Should 'Present' be the value for None or should it be '-' a dash

--------
<img width="1244" alt="Screenshot 2022-11-17 at 10 01 26" src="https://user-images.githubusercontent.com/25043924/202416437-bfa8f1e6-70ef-4d40-9ad7-9350f612a439.png">

-------

<img width="1181" alt="Screenshot 2022-11-17 at 10 02 54" src="https://user-images.githubusercontent.com/25043924/202416815-a88c6e27-6c02-4b21-b099-7c3a68161dc5.png">
