### PR TITLE
Add securityContext to kubernetes deployment config

### DIFF
--- a/kubernetes_deploy/live/dev/deployment.yaml
+++ b/kubernetes_deploy/live/dev/deployment.yaml
@@ -50,3 +50,9 @@ spec:
               key: key
         - name: ENV
           value: dev
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false

--- a/kubernetes_deploy/live/production/deployment.yaml
+++ b/kubernetes_deploy/live/production/deployment.yaml
@@ -55,3 +55,9 @@ spec:
               key: key
         - name: ENV
           value: production
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false

--- a/kubernetes_deploy/live/staging/deployment.yaml
+++ b/kubernetes_deploy/live/staging/deployment.yaml
@@ -55,3 +55,9 @@ spec:
               key: key
         - name: ENV
           value: staging
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false


### PR DESCRIPTION
#### What

We do not currently configure the security context for our kubernetes deployments. This exposes us to several security vulnerabilities, which are being flagged by Snyk's Infrastructure as Code scanning: https://app.snyk.io/org/legal-aid-agency/project/749f9c3d-91a9-45d1-8f6b-f5b862888344

This change sets three security configurations for our kubenetes containers which ensure that the container runs:

* with restricted capabilities, so that the container is not running with potentially unnecessary privileges;
* as non-root, so that the container is not running with full admin privileges;
* with privilege escalation control, so that compromised process cannot elevate privileges.

There is one further change that could be made (set `readOnlyRootFilesystem: true`) however this causes deployment failures and will be addressed in a later change.

#### How 

Add the following block to the container definition in `kubernetes_deploy/live/<env>/deployment.yaml` for all three environments:

```        
securityContext:
  capabilities:
    drop:
    - ALL
  runAsNonRoot: true
  allowPrivilegeEscalation: false
```

## Further reading
https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
https://kubesec.io/basics/
https://cloudogu.com/en/blog/k8s-app-ops-part-3-security-context-1
