### PR TITLE
Do not log 'OSError write errors' in Sentry

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -13,3 +13,4 @@ socket = /tmp/uwsgi.sock
 post-buffering = 1
 buffer-size = 65535
 http-timeout = 20
+disable-write-exception = true


### PR DESCRIPTION
#### What

We occasionally see occurances of `OSError write error` in the #laa-fee-calculator-alerts slack channel. This appears to be a harmless exception which causes no issue for users but does cause noise for developers.

It can be recreated by reloading a page in the fee scheme viewer multiple times (eg navigating to https://staging.laa-fee-calculator.service.justice.gov.uk/viewer/fee_schemes/1 and hitting refresh a few times).

No error occurs on screen but three lines are added to the logs. The third of these causes a Sentry alert to trigger.

```
Fri Dec 23 09:21:45 2022 - SIGPIPE: writing to a closed pipe/socket/fd (probably the client disconnected) on request /viewer/fee_schemes/1 (ip 172.20.103.83) !!!
Fri Dec 23 09:21:45 2022 - uwsgi_response_writev_headers_and_body_do(): Broken pipe [core/writer.c line 306] during GET /viewer/fee_schemes/1 (172.20.103.83)
OSError: write error
```

#### How

This fixes the issue by setting `disable-write-exception` to `true` in the `uwsgi` settings as recommended here:

https://stumbles.id.au/how-to-fix-uwsgi-oserror-write-error.html

This causes the third line of the three above to not be logged, preventing noise in the alerts slack channel.

The suggestion is to also set `ignore-sigpipe` and `ignore-write-errors`, which will prevent the first two lines being logged, however it feels like we shouldn't be disabling too much logging in case we accidentally hide something useful, so I have not included those.


#### Proof

Before - `OSError: write error` is logged and sentry alert triggered: https://mojdt.slack.com/archives/C02DST7JZNY/p1671787311776759

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/28729201/209316700-f81613c2-fbe6-45a0-b946-5086566bc5cd.png">


After - no `OSError: write error` is logged, no sentry alert triggered:

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/28729201/209316766-23e01f59-1352-4b15-9a7e-f1afefa4b328.png">
