### PR TITLE
Fix local running of tests

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,7 +87,7 @@ venv/bin/python -m coverage report
 * Run an individual test
 
 ```
-venv/bin/python manage.py test calculator.tests.test_calculation_agfs_12
+venv/bin/python manage.py test calculator.tests.test_calculation_05_agfs_12
 ```
 
 ## Running locally using docker

--- a/requirements/circleci.txt
+++ b/requirements/circleci.txt
@@ -1,4 +1,2 @@
 -r base.txt
-
-coverage>=6.4.1
-unittest-xml-reporting>=3.2.0
+-r test.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,1 +1,2 @@
 -r base.txt
+-r test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,2 @@
+coverage>=6.4.1
+unittest-xml-reporting>=3.2.0


### PR DESCRIPTION
#### What

Allow developers to successfully run the test suite locally

#### Why

After a recent OS upgrade I had to reinstall python and django. After installing local dependencies `venv/bin/pip install -r requirements/local.txt` I ran the tests and received the error `ModuleNotFoundError: No module named 'xmlrunner'`.

This is because two dependencies which are required for running test are only included in `requirements/circleci.txt`, not `requirements/local.txt`.

#### How

To fix this I've moved those dependencies to a new `requirements/test.txt` file and included that in the `local` and `circleci` requirements. 

This means that those files are now identical. Maybe we should drop them completely and run everything from `requirements/base.txt`?