### PR TITLE
Increase parellel test executors from 2 to 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
 
   test-calculator:
     executor: cloud-platform-executor
-    parallelism: 2
+    parallelism: 3
     steps:
       - checkout
       - setup_python_env


### PR DESCRIPTION
#### What

Increase test parallelism from 2 to 3

#### Why

The `test-calculator` CircleCI job runs in parallel on two executors. As we have added new fee schemes the number of tests has increased and the tests now take > 12 minutes to complete.

This increases the number of parallel executors to 3 which reduces the time taken to run the test-calculator` suite to about 8 minutes.

I tested with other combinations of parallelism and resource size but this seemed to give the best bang/buck ratio.

| Servers |  Resource size | Time taken |
|---------|---------------|-------------|
| 2 |  Medium | 12:32 |
| 3 |  Medium | 8:34 |
| 3 |  Large | 8:50 |
| 4 |  Medium | 8:32 |