### PR TITLE
Add AGFS Fee Scheme 15

### DIFF
--- a/fee_calculator/apps/api/tests/test_filters.py
+++ b/fee_calculator/apps/api/tests/test_filters.py
@@ -3,7 +3,7 @@ from calculator.models import Scheme
 from calculator.constants import SCHEME_TYPE
 from api.filters import SchemeFilter
 
-NUMBER_OF_AGFS_SCHEMES = 7
+NUMBER_OF_AGFS_SCHEMES = 8
 NUMBER_OF_LGFS_SCHEMES = 3
 
 LGFS_SCHEME_NINE_ID = 2

--- a/fee_calculator/apps/calculator/fixtures/scheme.json
+++ b/fee_calculator/apps/calculator/fixtures/scheme.json
@@ -103,10 +103,21 @@
     "pk": 10,
     "fields": {
       "start_date": "2023-02-01",
-      "end_date": null,
+      "end_date": "2023-04-16",
       "earliest_main_hearing_date": null,
       "base_type": 1,
       "description": "AGFS Fee Scheme 14 (2023-02 - Section 28)"
+    }
+  },
+  {
+    "model": "calculator.scheme",
+    "pk": 11,
+    "fields": {
+      "start_date": "2023-04-17",
+      "end_date": null,
+      "earliest_main_hearing_date": null,
+      "base_type": 1,
+      "description": "AGFS Fee Scheme 15 (2023-04 - Additional Preparation Fee)"
     }
   }
 ]


### PR DESCRIPTION
#### What

Create a new Fee Scheme 15.

#### Ticket

[Fee Calc - Create Fee Scheme 15](https://dsdmoj.atlassian.net/browse/CTSKF-360)

#### Why

A new fee scheme is required to;

* Add a new 'additional preparation fee'
* Change the 'QC' advocate category to 'KC'

These will be added to the new fee scheme in subsequent tickets.

#### How

Duplicate AGFS Fee Scheme 14 following the [instructions in the `README.md`.](https://github.com/ministryofjustice/laa-fee-calculator#new-fee-schemes)