### PR TITLE
Update to use new short-lived credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
       - run:
           name: Push laa-fee-calculator docker image
           command: |
-            aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
+            aws ecr get-login-password --region ${ECR_REGION} | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
 
             component=app
             docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${component}-${CIRCLE_SHA1}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ commands:
       - run:
           name: Push laa-fee-calculator docker image
           command: |
-            aws ecr get-login-password --region ${ECR_REGION} | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
+            aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
 
             component=app
             docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${component}-${CIRCLE_SHA1}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  aws-cli: circleci/aws-cli@4.0.0
+
 references:
   create-tmp-dir: &create-tmp-dir
     run:
@@ -64,6 +67,9 @@ commands:
     description: >
       Push laa-fee-calculator docker image
     steps:
+      - aws-cli/setup:
+          role_arn: $ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
       - run:
           name: Push laa-fee-calculator docker image
           command: |


### PR DESCRIPTION
#### What

Update the CircleCI pipeline in line with the new credentials for ECR.

#### Ticket

[Fee Calculator - Deprecate long-lived credentials for ECR](https://dsdmoj.atlassian.net/browse/CTSKF-437)

#### Why

Cloud Platform are deprecating the long-lived credentials for container repositories so pipelines need to be updated.

#### How

See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html

The following new environment variables have been added to the [context in CircleCI:](https://app.circleci.com/settings/organization/github/ministryofjustice/contexts/4f174588-935a-4587-ae3b-ed9d37489060)

* `ECR_ROLE_TO_ASSUME`

This is then used by the `aws-cli` orb to set the role.