### PR TITLE
[DO NOT MERGE] Set Fee Scheme 16 date for testing

### DIFF
--- a/fee_calculator/apps/calculator/fixtures/scheme.json
+++ b/fee_calculator/apps/calculator/fixtures/scheme.json
@@ -114,7 +114,7 @@
     "pk": 11,
     "fields": {
       "start_date": "2023-04-17",
-      "end_date": "2023-11-15",
+      "end_date": "2023-10-15",
       "earliest_main_hearing_date": null,
       "base_type": 1,
       "description": "AGFS Fee Scheme 15 (2023-04 - Additional Preparation Fee)"
@@ -124,7 +124,7 @@
     "model": "calculator.scheme",
     "pk": 12,
     "fields": {
-      "start_date": "2023-11-16",
+      "start_date": "2023-10-16",
       "end_date": null,
       "earliest_main_hearing_date": null,
       "base_type": 1,


### PR DESCRIPTION
#### What

Set the start date for Fee Scheme 16 early for testing.

#### Ticket

[Fee Calculator - Develop new Fee Scheme data](https://dsdmoj.atlassian.net/browse/CTSKF-596)

#### Why

CCCD will not allow claims with dates in the future so to test the few fee scheme it is necessary that the start date has already passed.

#### How

Adjust the dates in `fee_calculator/apps/calculator/fixtures/scheme.json` to make the new fee scheme start on 16 October 2023.