### PR TITLE
[CTSKF-314] Upgrade to Django 4

### DIFF
--- a/fee_calculator/apps/api/urls.py
+++ b/fee_calculator/apps/api/urls.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import url, include
-from django.urls import path
+from django.urls import include, path, re_path
 
 from rest_framework_nested import routers
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
@@ -33,9 +32,9 @@ schemes_router.register(r'modifier-types', ModifierTypeViewSet,
 schemes_router.register(r'prices', PriceViewSet, basename='prices')
 
 urlpatterns = (
-    url(r'^fee-schemes/(?P<scheme_pk>[^/.]+)/calculate/$', CalculatorView.as_view(), name='calculator'),
-    url(r'^', include(router.urls)),
-    url(r'^', include(schemes_router.urls)),
+    re_path(r'^fee-schemes/(?P<scheme_pk>[^/.]+)/calculate/$', CalculatorView.as_view(), name='calculator'),
+    re_path(r'^', include(router.urls)),
+    re_path(r'^', include(schemes_router.urls)),
 
     # drf-spectacular = OpenAPI3
     path('oa3/schema/', SpectacularAPIView.as_view(), name='oa3_schema'),

--- a/fee_calculator/apps/calculator/management/commands/loadbulkdata.py
+++ b/fee_calculator/apps/calculator/management/commands/loadbulkdata.py
@@ -10,7 +10,7 @@ from django.core.management.commands.loaddata import (
 from django.db import (
     DatabaseError, IntegrityError, router
 )
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 class Command(LoadDataCommand):
@@ -94,7 +94,7 @@ class Command(LoadDataCommand):
                         e.args = ("Could not load %(app_label)s.%(object_name)s: %(error_msg)s" % {
                             'app_label': model._meta.app_label,
                             'object_name': model._meta.object_name,
-                            'error_msg': force_text(e)
+                            'error_msg': force_str(e)
                         },)
                         raise
                 else:
@@ -112,7 +112,7 @@ class Command(LoadDataCommand):
                                 'app_label': obj.object._meta.app_label,
                                 'object_name': obj.object._meta.object_name,
                                 'pk': obj.object.pk,
-                                'error_msg': force_text(e)
+                                'error_msg': force_str(e)
                             },)
                             raise
                 if objects and show_progress:

--- a/fee_calculator/settings/base.py
+++ b/fee_calculator/settings/base.py
@@ -208,8 +208,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/fee_calculator/urls.py
+++ b/fee_calculator/urls.py
@@ -5,16 +5,16 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Import the include() function: from django.urls import re_path, include
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import url, include
+from django.urls import include, re_path
 from django.shortcuts import redirect
 from django.contrib import admin
 
@@ -22,15 +22,15 @@ from moj_irat.views import PingJsonView, HealthcheckView
 
 
 urlpatterns = [
-    url(r'^$', lambda req: redirect('/api/v1')),
-    url(r'^api/v1/', include('api.urls')),
-    url(r'^ping.json$', PingJsonView.as_view(**settings.PING_JSON_KEYS),
-        name='ping_json'),
-    url(r'^healthcheck.json$', HealthcheckView.as_view(),
-        name='healthcheck_json'),
-    url(r'^viewer/', include('viewer.urls'))
+    re_path(r'^$', lambda req: redirect('/api/v1')),
+    re_path(r'^api/v1/', include('api.urls')),
+    re_path(r'^ping.json$', PingJsonView.as_view(**settings.PING_JSON_KEYS),
+            name='ping_json'),
+    re_path(r'^healthcheck.json$', HealthcheckView.as_view(),
+            name='healthcheck_json'),
+    re_path(r'^viewer/', include('viewer.urls'))
 ]
 
 
 if settings.ADMIN_ENABLED:
-    urlpatterns.append(url(r'^admin/', admin.site.urls))
+    urlpatterns.append(re_path(r'^admin/', admin.site.urls))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==3.2.23
+Django==4.2.9
 django-moj-irat==0.9
 drf-spectacular==0.27.0
 djangorestframework==3.14.0


### PR DESCRIPTION
#### What

Upgrade the Django framework to the latest minor version of v4 (4.2.9).

#### Ticket

[CTSKF-314](https://dsdmoj.atlassian.net/browse/CTSKF-314)

#### Why

The current version of the framework (3.2) goes out of support in April 2024. We should update to a newer version to ensure continued support and maintain a secure and reliable service.

#### How

Based on https://dsdmoj.atlassian.net/wiki/spaces/CT/pages/4642406465/CTSKF-322+What+effects+would+updating+Django+framework+have+on+Fee+Calculator.

* Update `requirements/base.txt`.
* Replace the use of `django.conf.urls()`, which has now been removed, with `django.urls.re_path()`.
* Replace the use of `django.utils.encoding.force_text()`, which has now been removed, with `django.utils.encoding.force_str()`.
* Delete the `USE_L10N` setting which is deprecated in Django 4 and will be removed
in Django 5, and has become default Django behaviour.

[CTSKF-314]: https://dsdmoj.atlassian.net/browse/CTSKF-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ