### PR TITLE
Improvements to setup process for local development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ setup: #: Install virtual environment and requirements
 	`which python3` -m venv venv
 	${px} install -U setuptools pip wheel
 	${px} install -r requirements/base.txt
+setup-local: #: Install virtual environment and requirements for local development environment
+	`which python3` -m venv venv
+	${px} install -U setuptools pip wheel
+	${px} install -r requirements/local.txt
 server: # run app server
 	DEBUG="True" ${pyman} runserver 8000
 db: #: open db console

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,7 +23,7 @@ brew link libxml2 --force
 **Quick start**
 
 ```
-make setup
+make setup-local
 make dbreload
 make server
 ```
@@ -41,7 +41,7 @@ venv/bin/pip install -U setuptools pip wheel
 * Install application dependencies
 
 ```
-venv/bin/pip install -r requirements/base.txt
+venv/bin/pip install -r requirements/local.txt
 ```
 
 * Create/Migrate database
@@ -116,7 +116,7 @@ docker-compose up
 
 Secrets should _not_ be kept in this repository. In the past `git-crypt` has been used to encrypt secrets within the repo however due to the difficulty of rotating the symmetric key used for encryption following a security breach, this approach has now been deprecated.
 
-Secrets are held as Kubernetes Secret objects in the cluster. These can be accessed by executing 
+Secrets are held as Kubernetes Secret objects in the cluster. These can be accessed by executing
 
 ```bash
 kubectl -n laa-fee-calculator-<env> get secrets


### PR DESCRIPTION


#### What

Improvements to setup process for local development environment

#### Ticket

No ticket

#### Why

Following the instructions as currently written results in errors when trying to run tests locally due to missing packages

#### How

*Created new command in the Makefile setup-local which calls requirements/local.txt rather than requirements/base.txt *Updated DEVELOPMENT.md instructions to recommend this command rather than setup.