### PR TITLE
Duplication between base.py and test_calculation_01_agfs_9.py

### DIFF
--- a/fee_calculator/apps/calculator/tests/test_calculation_01_agfs_9.py
+++ b/fee_calculator/apps/calculator/tests/test_calculation_01_agfs_9.py
@@ -3,14 +3,13 @@ from decimal import Decimal
 from math import floor
 import os
 
-from django.conf import settings
 from rest_framework import status
 
 from calculator.tests.lib.utils import scenario_ccr_to_id
-from calculator.tests.base import AgfsCalculatorTestCase
+from calculator.tests.base import AgfsCalculatorTestCase, FeeTypeUnitMixin
 
 
-class Agfs9CalculatorTestCase(AgfsCalculatorTestCase):
+class Agfs9CalculatorTestCase(AgfsCalculatorTestCase, FeeTypeUnitMixin):
     scheme_id = 1
     csv_path = os.path.join(
         os.path.dirname(__file__),
@@ -33,21 +32,7 @@ class Agfs9CalculatorTestCase(AgfsCalculatorTestCase):
 
         if not is_basic:
             # get unit for fee type
-            unit_resp = self.client.get(
-                '/api/{version}/fee-schemes/{scheme_id}/units/'.format(
-                    version=settings.API_VERSION, scheme_id=self.scheme_id),
-                data=data
-            )
-            self.assertEqual(
-                unit_resp.status_code, status.HTTP_200_OK, unit_resp.content
-            )
-            self.assertEqual(unit_resp.json()['count'], 1, data)
-            unit = unit_resp.json()['results'][0]['id']
-            data[unit] = (
-                Decimal(row['NUM_ATTENDANCE_DAYS'])
-                if row['BILL_TYPE'] == 'AGFS_FEE'
-                else Decimal(row['QUANTITY'])
-            ) or 1
+            self.get_fee_type_unit(data, row)
         else:
             data['DAY'] = Decimal(row['NUM_ATTENDANCE_DAYS']) or 1
             data['PPE'] = int(row['PPE'])


### PR DESCRIPTION
Draft PR to trigger sonarcloud to look at this

#### What
Reduced duplication in the AGFS Calculator test cases

#### Ticket

[CTSKF-104](https://dsdmoj.atlassian.net/browse/CTSKF-104)

#### Why

- Follow DRY principles
- Mixin can be reused in the future for new classes

#### How

- Extracted one duplicated code block into new method get_fee_unit_type which has been placed in a new Mixin class, FeeTypeUnitMixin



[CTSKF-104]: https://dsdmoj.atlassian.net/browse/CTSKF-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ