### PR TITLE
Fix K8s warnings

### DIFF
--- a/kubernetes_deploy/live/dev/deployment.yaml
+++ b/kubernetes_deploy/live/dev/deployment.yaml
@@ -56,3 +56,5 @@ spec:
             - ALL
           runAsNonRoot: true
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault

--- a/kubernetes_deploy/live/production/deployment.yaml
+++ b/kubernetes_deploy/live/production/deployment.yaml
@@ -61,3 +61,5 @@ spec:
             - ALL
           runAsNonRoot: true
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault

--- a/kubernetes_deploy/live/staging/deployment.yaml
+++ b/kubernetes_deploy/live/staging/deployment.yaml
@@ -61,3 +61,5 @@ spec:
             - ALL
           runAsNonRoot: true
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
#### What

Update kubernetes securityContexts to reduce warnings


#### Why

The Cloud Platform upgrade of the kubernetes cluster to v1.26 has resulted in warnings of a missing security context being displayed when deploying the application, eg:

```
Warning: would violate PodSecurity "restricted:latest": seccompProfile (pod or container "app" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

#### How

Defines `seccompProfile` in all kubernetes config files with a value of `RuntimeDefault`, which allows us to default to the container's security profile.

#### Screenshots

Before:

<img width="1198" alt="image" src="https://github.com/ministryofjustice/laa-fee-calculator/assets/28729201/c3158bf0-416d-45cc-86f0-f8ce30b21e84">


After: 

<img width="896" alt="image" src="https://github.com/ministryofjustice/laa-fee-calculator/assets/28729201/848c4e7a-7e2b-42f8-aa10-5ab01b630cfe">
