### PR TITLE
Block requests from GPTBot

### DIFF
--- a/kubernetes_deploy/live/dev/ingress.yaml
+++ b/kubernetes_deploy/live/dev/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRule REQUEST_HEADERS:User-Agent "@contains GPTBot" "id:1001, phase:1, deny, status:403, log"
   name: laa-fee-calculator-v1
   namespace: laa-fee-calculator-dev
 spec:

--- a/kubernetes_deploy/live/production/ingress.yaml
+++ b/kubernetes_deploy/live/production/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRule REQUEST_HEADERS:User-Agent "@contains GPTBot" "id:1001, phase:1, deny, status:403, log"
   name: laa-fee-calculator-v1
   namespace: laa-fee-calculator-production
 spec:

--- a/kubernetes_deploy/live/staging/ingress.yaml
+++ b/kubernetes_deploy/live/staging/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRule REQUEST_HEADERS:User-Agent "@contains GPTBot" "id:1001, phase:1, deny, status:403, log"
   name: laa-fee-calculator-v1
   namespace: laa-fee-calculator-staging
 spec:


### PR DESCRIPTION
#### What

Block requests from GPTBot

#### Why

We have seen some alerts caused by GPTBot crawling the application and making requests that fail. Although there appears to be nothing malicious taking place, to prevent noise we can block these requests by adding a modsecurity rule to our ingress to block this bot.

#### Testing

Can be tested by running 
```
curl -A "GPTBot/1.0" https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/6/calculate/\?day\=9\&fee_type_code\=LIT_FEE\&number_of_defendants\=2\&offence_class\=B\&pages_of_prosecuting_evidence\=0\&ppe\=81\&scenario\=46\&trial_length\=
```

This currently returns an error message. With the WAF rule in place it now blocks the request:

```
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx</center>
</body>
</html>
```