### PR TITLE
[CTSKF 1170] Update ingressClassName in non-prod environments

### DIFF
--- a/kubernetes_deploy/live/dev/ingress.yaml
+++ b/kubernetes_deploy/live/dev/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   name: laa-fee-calculator-v1
   namespace: laa-fee-calculator-dev
 spec:
-  ingressClassName: modsec
+  ingressClassName: modsec-non-prod
   rules:
     - host: dev.laa-fee-calculator.service.justice.gov.uk
       http:

--- a/kubernetes_deploy/live/staging/ingress.yaml
+++ b/kubernetes_deploy/live/staging/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   name: laa-fee-calculator-v1
   namespace: laa-fee-calculator-staging
 spec:
-  ingressClassName: modsec
+  ingressClassName: modsec-non-prod
   rules:
     - host: staging.laa-fee-calculator.service.justice.gov.uk
       http:


### PR DESCRIPTION
#### What

Set the version of modsec for testing.

#### Ticket

[[Fee Calculator] Update modsec in non-prod](https://dsdmoj.atlassian.net/browse/CTSKF-1170)

#### Why

ModSec is being updated and a test ingress controller has been provided.

#### How

Change `ingressClassName: modsec` to `ingressClassName: modsec-non-prod` in all non-prod environments.
