### PR TITLE
Remove reviewers fields from dependabot.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/laa-claim-for-payment @ministryofjustice/laa-clair-taskforce
+* @ministryofjustice/laa-clair-taskforce

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
   allow:
     - dependency-type: "all"
   rebase-strategy: "disabled"
-  reviewers:
-  - "ministryofjustice/laa-claim-for-payment"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -22,5 +20,3 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 10
   rebase-strategy: "disabled"
-  reviewers:
-  - "ministryofjustice/laa-claim-for-payment"


### PR DESCRIPTION
#### What

Updates `.github/dependabot.yml` and `.github/CODEOWNERS`

#### Why

Dependabot PRs are being annotated with the following comment:

```
The reviewers field in the dependabot.yml file will be removed soon.
Please use the code owners file to specify reviewers for Dependabot PRs
```

#### How

* Deletes `reviewers` fields from `.github/dependabot.yml`
* Updates `.github/CODEOWNERS` to remove reference to the old `laa-claim-for-payment` github team.