### PR TITLE
Add back scenarios view

### DIFF
--- a/fee_calculator/apps/viewer/views.py
+++ b/fee_calculator/apps/viewer/views.py
@@ -11,8 +11,7 @@ from viewer.presenters.scenario_presenters import scenario_presenter_factory
 def index(request):
     sections = [
         {'page': 'viewer:fee_schemes', 'title': 'Fee Schemes'},
-        # WIP
-        # {'page': 'viewer:scenarios', 'title': 'Scenarios'}
+        {'page': 'viewer:scenarios', 'title': 'Scenarios'}
     ]
 
     return render(request, 'viewer/index.html', {'sections': sections})


### PR DESCRIPTION
#### What

Re-enable scenarios view

#### Why

This was commented out in [this commit](https://github.com/ministryofjustice/laa-fee-calculator/commit/93cef940634a4500cf91f5da87f8ba0850364124) as it was a work in progress. The scenarios page is now complete and can be viewed at https://laa-fee-calculator.service.justice.gov.uk/viewer/scenarios. This PR adds back a link to the scenarios page under the `/viewer` path.