### PR TITLE
Use sha for Github action checkout versions

### DIFF
--- a/.github/workflows/docker_image_scan.yml
+++ b/.github/workflows/docker_image_scan.yml
@@ -9,7 +9,7 @@ jobs:
     name: Scan docker image
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Build docker image
       run: |
@@ -20,7 +20,7 @@ jobs:
 
     - name: Scan docker image using snyk
       id: image-scan
-      uses: snyk/actions/docker@master
+      uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04
       continue-on-error: true
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
 
     - name: Monitor docker image using snyk
       id: image-monitor
-      uses: snyk/actions/docker@master
+      uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
@@ -39,13 +39,13 @@ jobs:
         args: --file=Dockerfile
 
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13
       with:
         sarif_file: snyk.sarif
 
     - name: Slack notify failure
       if: ${{ steps.image-scan.outcome == 'failure' }}
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
       env:
         SLACK_USERNAME: Snyk docker image scan
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -59,7 +59,7 @@ jobs:
 
     - name: Slack notify success
       if: ${{ steps.image-scan.outcome == 'success' }}
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
       env:
         SLACK_USERNAME: Snyk docker image scan
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
#### What

Use sha instead of version number for Github actions.

#### Ticket

N/A

#### Why

To avoid supply chain attacks.

#### How

Replace versions with commit shas in `.github/workflows/docker_image_scan.yml`